### PR TITLE
Use devel branch of superimpose-mesh-lib.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,9 +53,9 @@ jobs:
         cmake --build . --config ${{ matrix.build_type }} --target install
 
         cd ${GITHUB_WORKSPACE}
-        git clone https://github.com/xenvre/superimpose-mesh-lib
+        git clone https://github.com/robotology/superimpose-mesh-lib
         cd superimpose-mesh-lib
-        git checkout of-aided-tracking
+        git checkout devel
         mkdir build
         cd build
         cmake -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE} ..

--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -46,8 +46,8 @@ RUN git clone https://github.com/robotology/ycm && \
     cd ycm && mkdir build && cd build && \
     cmake .. && \
     make install
-RUN git clone https://github.com/xenvre/superimpose-mesh-lib && \
-    cd superimpose-mesh-lib && git checkout of-aided-tracking && mkdir build && cd build && \
+RUN git clone https://github.com/robotology/superimpose-mesh-lib && \
+    cd superimpose-mesh-lib && git checkout devel && mkdir build && cd build && \
     cmake .. && \
     make install
 

--- a/src/roft-lib/CMakeLists.txt
+++ b/src/roft-lib/CMakeLists.txt
@@ -53,6 +53,9 @@ set(${LIBRARY_TARGET_NAME}_HDR
     include/ROFT/QuaternionModel.h
     include/ROFT/ROFTFilter.h
     include/ROFT/SpatialVelocityModel.h
+    include/ROFT/SICAD.h
+    include/ROFT/SICADModel.h
+    include/ROFT/SICADShader.h
     include/ROFT/SKFCorrection.h
     include/ROFT/UKFCorrection.h
 )
@@ -74,6 +77,9 @@ set(${LIBRARY_TARGET_NAME}_SRC
     src/QuaternionModel.cpp
     src/ROFTFilter.cpp
     src/SpatialVelocityModel.cpp
+    src/SICAD.cpp
+    src/SICADModel.cpp
+    src/SICADShader.cpp
     src/SKFCorrection.cpp
     src/UKFCorrection.cpp
 )
@@ -101,6 +107,13 @@ cmrc_add_resource_library(${LIBRARY_TARGET_NAME}_Resources
                           meshes/DOPE/009_gelatin_box.obj
                           meshes/DOPE/010_potted_meat_can.obj
                           meshes/DOPE/021_bleach_cleanser.obj
+                          shader/shader_background.frag
+                          shader/shader_background.vert
+                          shader/shader_frame.frag
+                          shader/shader_frame.vert
+                          shader/shader_model.frag
+                          shader/shader_model_texture.frag
+                          shader/shader_model.vert
 )
 
 # Add library

--- a/src/roft-lib/include/ROFT/ROFTFilter.h
+++ b/src/roft-lib/include/ROFT/ROFTFilter.h
@@ -21,13 +21,12 @@
 #include <ROFT/ImageSegmentationMeasurement.h>
 #include <ROFT/ImageSegmentationSource.h>
 #include <ROFT/ModelParameters.h>
+#include <ROFT/SICAD.h>
 
 #include <RobotsIO/Camera/Camera.h>
 #include <RobotsIO/Utils/ProbeContainer.h>
 #include <RobotsIO/Utils/SpatialVelocityBuffer.h>
 #include <RobotsIO/Utils/Transform.h>
-
-#include <SuperimposeMesh/SICAD.h>
 
 #include <opencv2/opencv.hpp>
 
@@ -151,7 +150,7 @@ private:
 
     RobotsIO::Camera::CameraParameters camera_parameters_;
 
-    std::unique_ptr<SICAD> renderer_;
+    std::unique_ptr<ROFT::SICAD> renderer_;
 
     const bool outlier_rejection_;
 

--- a/src/roft-lib/include/ROFT/SICAD.h
+++ b/src/roft-lib/include/ROFT/SICAD.h
@@ -1,0 +1,506 @@
+/*
+ * Copyright (C) 2022 Istituto Italiano di Tecnologia (IIT)
+ *
+ * This software may be modified and distributed under the terms of the
+ * GPL-2+ license. See the accompanying LICENSE file for details.
+ *
+ *
+ * Part of this code is taken from https://github.com/robotology/superimpose-mesh-lib/commits/impl/depth
+ *
+ * This is the original BSD 3-Clause LICENSE the original code was provided with:
+ *
+ * Copyright (c) 2016-2019, Istituto Italiano di Tecnologia (IIT) All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+ * - Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ * - Neither the name of the organization nor the names of its contributors may be used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL CLAUDIO FANTACCI BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef ROFT_SICAD_H
+#define ROFT_SICAD_H
+
+#include <SuperimposeMesh/Superimpose.h>
+
+#include <ROFT/SICADShader.h>
+#include <ROFT/SICADModel.h>
+
+#include <istream>
+#include <memory>
+#include <string>
+#include <thread>
+#include <utility>
+#include <vector>
+
+#include <GL/glew.h>
+#include <GLFW/glfw3.h>
+#include <glm/glm.hpp>
+
+namespace ROFT {
+    class SICAD;
+}
+
+
+/**
+ * A Superimpose derived class to superimpose mesh models on images.
+ */
+class ROFT::SICAD : public Superimpose
+{
+public:
+    typedef typename std::unordered_map<std::string, std::string> ModelPathContainer;
+
+    typedef typename std::unordered_map<std::string, std::basic_istream<char>*> ModelStreamContainer;
+
+    typedef typename std::pair<std::string, std::string> ModelPathElement;
+
+    typedef typename std::pair<std::string, std::basic_istream<char>*> ModelStreamElement;
+
+    typedef typename std::unordered_map<std::string, SICADModel*> ModelContainer;
+
+    typedef typename std::pair<std::string, SICADModel*> ModelElement;
+
+    enum class MIPMaps
+    {
+        nearest,
+        linear
+    };
+
+    /**
+     * Create a SICAD object with a dedicated OpenGL context and default shaders.
+     *
+     * Only 1 image will be rendered in the OpenGL context.
+     *
+     * The reference frame of the OpenGL virtual camera is the standard right-handed system and can be
+     * changed by means of `setOglToCam()' method.
+     *
+     * @param objfile_map A (tag, path) container to associate a 'tag' to the mesh file specified in 'path'.
+     * @param cam_width Camera or image width.
+     * @param cam_height Camera or image height.
+     * @param cam_fx focal Length along the x axis in pixels.
+     * @param cam_fy focal Length along the y axis in pixels.
+     */
+    SICAD(const ModelPathContainer& objfile_map, const GLsizei cam_width, const GLsizei cam_height, const GLfloat cam_fx, const GLfloat cam_fy, const GLfloat cam_cx, const GLfloat cam_cy);
+
+    /**
+     * Create a SICAD object with a dedicated OpenGL context and default shaders.
+     *
+     * Only 1 image will be rendered in the OpenGL context.
+     *
+     * The reference frame of the OpenGL virtual camera is the standard right-handed system and can be
+     * changed by means of `ogl_to_cam` parameter.
+     *
+     * @param objstream_map A (tag, stream) container to associate a 'tag' to the mesh file contained in the stream 'stream'.
+     * @param cam_width Camera or image width.
+     * @param cam_height Camera or image height.
+     * @param cam_fx focal Length along the x axis in pixels.
+     * @param cam_fy focal Length along the y axis in pixels.
+     */
+    SICAD(const ModelStreamContainer& objstream_map, const GLsizei cam_width, const GLsizei cam_height, const GLfloat cam_fx, const GLfloat cam_fy, const GLfloat cam_cx, const GLfloat cam_cy);
+
+    /**
+     * Create a SICAD object with a dedicated OpenGL context and default shaders.
+     *
+     * Up to `num_images` images will be rendered in the same OpenGL context and the result of
+     * the process will be tiled up in a regular grid. This implies that the total number
+     * of rendered images may be less than or equal to the required `num_images`. The total
+     * number of rendered images is chosen to optimize performance and accessibility and can be
+     * accessed through `SICAD::getTilesNumber()`.
+     *
+     * The reference frame of the OpenGL virtual camera is the standard right-handed system and can be
+     * changed by means of `setOglToCam()' method.
+     *
+     * @param objfile_map A (tag, path) container to associate a 'tag' to the mesh file specified in 'path'.
+     * @param cam_width Camera or image width.
+     * @param cam_height Camera or image height.
+     * @param cam_fx focal Length along the x axis in pixels.
+     * @param cam_fy focal Length along the y axis in pixels.
+     * @param num_images Number of images (i.e. viewports) rendered in the same GL context.
+     */
+    SICAD(const ModelPathContainer& objfile_map, const GLsizei cam_width, const GLsizei cam_height, const GLfloat cam_fx, const GLfloat cam_fy, const GLfloat cam_cx, const GLfloat cam_cy, const GLint num_images);
+
+    /**
+     * Create a SICAD object with a dedicated OpenGL context and default shaders.
+     *
+     * Up to `num_images` images will be rendered in the same OpenGL context and the result of
+     * the process will be tiled up in a regular grid. This implies that the total number
+     * of rendered images may be less than or equal to the required `num_images`. The total
+     * number of rendered images is chosen to optimize performance and accessibility and can be
+     * accessed through `SICAD::getTilesNumber()`.
+     *
+     * The reference frame of the OpenGL virtual camera is the standard right-handed system.
+     *
+     * @param objstream_map A (tag, stream) container to associate a 'tag' to the mesh file contained in the stream 'stream'.
+     * @param cam_width Camera or image width.
+     * @param cam_height Camera or image height.
+     * @param cam_fx focal Length along the x axis in pixels.
+     * @param cam_fy focal Length along the y axis in pixels.
+     * @param num_images Number of images (i.e. viewports) rendered in the same GL context.
+     */
+    SICAD(const ModelStreamContainer& objstream_map, const GLsizei cam_width, const GLsizei cam_height, const GLfloat cam_fx, const GLfloat cam_fy, const GLfloat cam_cx, const GLfloat cam_cy, const GLint num_images);
+
+    /**
+     * Create a SICAD object with a dedicated OpenGL context and custom shaders.
+     * The folder where the shaders are stored can be specified in `shader_folder`.
+     *
+     * The following shaders with this exact names are needed:
+     *
+     *  - `shader_model.vert` for the vertex shader for mesh models
+     *  - `shader_model.frag` for the fragment shader for mesh models
+     *  - `shader_model_texture.frag` for the fragment shader for textured mesh models
+     *
+     *  - `shader_frame.vert` for the vertex shader for reference frames
+     *  - `shader_frame.frag` for the fragment shader for reference frames
+     *
+     *  - `shader_background.vert` for the vertex shader for background
+     *  - `shader_background.frag` for the fragment shader for background
+     *
+     * Up to `num_images` images will be rendered in the same OpenGL context and the result of
+     * the process will be tiled up in a regular grid. This implies that the total number
+     * of rendered images may be less than or equal to the required `num_images`. The total
+     * number of rendered images is chosen to optimize performance and accessibility and can be
+     * accessed through `SICAD::getTilesNumber()`.
+     *
+     * The reference frame of the OpenGL virtual camera is the standard right-handed system.
+     *
+     * @param objfile_map A (tag, path) container to associate a 'tag' to the mesh file specified in 'path'.
+     * @param cam_width Camera or image width.
+     * @param cam_height Camera or image height.
+     * @param cam_fx focal Length along the x axis in pixels.
+     * @param cam_fy focal Length along the y axis in pixels.
+     * @param num_images Number of images (i.e. viewports) rendered in the same GL context.
+     * @param shader_folder Path to the folder containing the above-mentioned required shaders.
+     */
+    SICAD(const ModelPathContainer& objfile_map, const GLsizei cam_width, const GLsizei cam_height, const GLfloat cam_fx, const GLfloat cam_fy, const GLfloat cam_cx, const GLfloat cam_cy, const GLint num_images, const std::string& shader_folder);
+
+    /**
+     * Create a SICAD object with a dedicated OpenGL context and custom shaders.
+     * The folder where the shaders are stored can be specified in `shader_folder`.
+     *
+     * The following shaders with this exact names are needed:
+     *
+     *  - `shader_model.vert` for the vertex shader for mesh models
+     *  - `shader_model.frag` for the fragment shader for mesh models
+     *  - `shader_model_texture.frag` for the fragment shader for textured mesh models
+     *
+     *  - `shader_frame.vert` for the vertex shader for reference frames
+     *  - `shader_frame.frag` for the fragment shader for reference frames
+     *
+     *  - `shader_background.vert` for the vertex shader for background
+     *  - `shader_background.frag` for the fragment shader for background
+     *
+     * Up to `num_images` images will be rendered in the same OpenGL context and the result of
+     * the process will be tiled up in a regular grid. This implies that the total number
+     * of rendered images may be less than or equal to the required `num_images`. The total
+     * number of rendered images is chosen to optimize performance and accessibility and can be
+     * accessed through `SICAD::getTilesNumber()`.
+     *
+     * The reference frame of the OpenGL virtual camera is the standard right-handed system and can be
+     * changed by means of `ogl_to_cam` or using the `setOglToCam()` method.
+     *
+     * @param objfile_map A (tag, path) container to associate a 'tag' to the mesh file specified in 'path'.
+     * @param cam_width Camera or image width.
+     * @param cam_height Camera or image height.
+     * @param cam_fx focal Length along the x axis in pixels.
+     * @param cam_fy focal Length along the y axis in pixels.
+     * @param num_images Number of images (i.e. viewports) rendered in the same GL context.
+     * @param shader_folder Path to the folder containing the above-mentioned required shaders.
+     * @param ogl_to_cam A 7-component pose vector, (x, y, z) position and a (ux, uy, uz, theta) axis-angle orientation, defining a camera rotation applied to the OpenGL camera.
+     */
+    SICAD(const GLsizei cam_width, const GLsizei cam_height, const GLfloat cam_fx, const GLfloat cam_fy, const GLfloat cam_cx, const GLfloat cam_cy, const GLint num_images, const std::string& shader_folder, const std::vector<float>& ogl_to_cam, const ModelPathContainer& objfile_map = ModelPathContainer(), const ModelStreamContainer& objstream_map = ModelStreamContainer());
+
+    virtual ~SICAD();
+
+    bool getOglWindowShouldClose();
+
+    void setOglWindowShouldClose(bool should_close);
+
+    /**
+     * Render the mesh models in the pose specified in `objpos_map` and move the virtual camera in `cam_x` position with orientation `cam_o`.
+     * The method then creates an image of the mesh models as they are seen by the virtual camera.
+     *
+     * @note If cv::Mat `img` is a background image it must be of size `cam_width * cam_height`, as specified during object construction,
+     * and the `SICAD::setBackgroundOpt(bool show_background)` must have been invoked with `true`.
+     *
+     * @param objpos_map A (tag, pose) container to associate a 7-component `pose`, (x, y, z) position and a (ux, uy, uz, theta) axis-angle orientation, to a mesh with tag 'tag'.
+     * @param cam_x (x, y, z) position.
+     * @param cam_o (ux, uy, uz, theta) axis-angle orientation.
+     * @param img An image representing the result of the superimposition. The variable is automatically resized if its size is not correct to store the entire result of the superimposition.
+     *
+     * @return true upon success, false otherswise.
+     **/
+    bool superimpose(const ModelPoseContainer& objpos_map, const double* cam_x, const double* cam_o, cv::Mat& img) override;
+
+    bool superimpose(const ModelPoseContainer& objpos_map, const double* cam_x, const double* cam_o, cv::Mat& img, cv::Mat& depth);
+
+    /**
+     * Render the mesh models in the pose specified in each element of `objpos_multimap` and move the virtual camera in
+     * `cam_x` position with orientation `cam_o`. Each group of meshes specified by the elements of `objpos_multimap` are rendered in a
+     * different viewport. Each viewport reports the mesh models as they are seen by the virtual camera.
+     * The method then creates a single image tiling the viewports in a regular grid.
+     *
+     * @note The size of the grid representing the tiled viewports can be accessed through `getTilesRows()` and `getTilesCols()`.
+     *
+     * @note If cv::Mat `img` is a background image it must be of size `cam_width * cam_height`, as specified during object construction,
+     * and the `SICAD::setBackgroundOpt(bool show_background)` must have been invoked with `true`.
+     *
+     * @param objpos_map A (tag, pose) container to associate a 7-component `pose`, (x, y, z) position and a (ux, uy, uz, theta) axis-angle orientation, to a mesh with tag 'tag'.
+     * @param cam_x (x, y, z) position.
+     * @param cam_o (ux, uy, uz, theta) axis-angle orientation.
+     * @param img An image representing the result of the superimposition. The variable is automatically resized if its size is not correct to store the entire result of the superimposition.
+     *
+     * @return true upon success, false otherswise.
+     **/
+    virtual bool superimpose(const std::vector<ModelPoseContainer>& objpos_multimap, const double* cam_x, const double* cam_o, cv::Mat& img);
+
+    virtual bool superimpose(const std::vector<ModelPoseContainer>& objpos_multimap, const double* cam_x, const double* cam_o, cv::Mat& img, cv::Mat& dept);
+
+    virtual bool superimpose(const ModelPoseContainer& objpos_map, const double* cam_x, const double* cam_o, cv::Mat& img,
+                             const GLsizei cam_width, const GLsizei cam_height, const GLfloat cam_fx, const GLfloat cam_fy, const GLfloat cam_cx, const GLfloat cam_cy);
+
+    virtual bool superimpose(const std::vector<ModelPoseContainer>& objpos_multimap, const double* cam_x, const double* cam_o, cv::Mat& img,
+                             const GLsizei cam_width, const GLsizei cam_height, const GLfloat cam_fx, const GLfloat cam_fy, const GLfloat cam_cx, const GLfloat cam_cy);
+
+    /**
+     * Render the mesh models in the pose specified in `objpos_map` and move the virtual camera in `cam_x` position with orientation `cam_o`.
+     * The method then stores the pixels of the mesh models as they are seen by the virtual camera in the `pbo_index`-th Pixel Buffer Object (PBO).
+     *
+     * @note By invoking this command rendered pixels are stored in the `pbo_index`-th PBO and, in order to use it, the OpenGL context must remain current.
+     * As a consequence, once you are done working with the `pbo_index`-th PBO (can be accessed by means of `SICAD::getPBO(pbo_index)`) and before invoking again
+     * any other `SICAD::superimpose()` function, you must invoke `SICAD::releaseContext()`.
+     *
+     * @param objpos_map A (tag, pose) container to associate a 7-component `pose`, (x, y, z) position and a (ux, uy, uz, theta) axis-angle orientation, to a mesh with tag 'tag'.
+     * @param cam_x (x, y, z) position.
+     * @param cam_o (ux, uy, uz, theta) axis-angle orientation.
+     * @param pbo_index The index of the PBO where the pixel are stored.
+     *
+     * @return (true, PBO) upon success, (false, 0) otherswise.
+     **/
+    virtual bool superimpose(const ModelPoseContainer& objpos_map, const double* cam_x, const double* cam_o, const size_t pbo_index);
+
+    /**
+     * Render the mesh models in the pose specified in `objpos_map` and move the virtual camera in `cam_x` position with orientation `cam_o`.
+     * The method then stores the pixels of the mesh models as they are seen by the virtual camera in the `pbo_index`-th Pixel Buffer Object (PBO).
+     *
+     * @note `img` must be of size `cam_width * cam_height`, as specified during object construction, and the
+     * `SICAD::setBackgroundOpt(bool show_background)` must have been invoked with `true`.
+     *
+     * @param objpos_map A (tag, pose) container to associate a 7-component `pose`, (x, y, z) position and a (ux, uy, uz, theta) axis-angle orientation, to a mesh with tag 'tag'.
+     * @param cam_x (x, y, z) position.
+     * @param cam_o (ux, uy, uz, theta) axis-angle orientation.
+     * @param pbo_index The index of the PBO where the pixel are stored.
+     * @param img A background image.
+     *
+     * @return (true, PBO) upon success, (false, 0) otherswise.
+     **/
+    virtual bool superimpose(const ModelPoseContainer& objpos_map, const double* cam_x, const double* cam_o, const size_t pbo_index, const cv::Mat& img);
+
+    /**
+     * Render the mesh models in the pose specified in each element of `objpos_multimap` and move the virtual camera in
+     * `cam_x` position with orientation `cam_o`. Each group of meshes specified by the elements of `objpos_multimap` are rendered in a
+     * different viewport. Each viewport reports the mesh models as they are seen by the virtual camera.
+     * The method then stores the pixels of the viewports in the `pbo_index`-th Pixel Buffer Object (PBO) by tiling them in a regular grid.
+     *
+     * @note By invoking this command rendered pixels are stored in the `pbo_index`-th PBO and, in order to use it, the OpenGL context must remain current.
+     * As a consequence, once you are done working with the `pbo_index`-th PBO (can be accessed by means of `SICAD::getPBO(pbo_index)`) and before invoking again
+     * any other `SICAD::superimpose()` function, you must invoke `SICAD::releaseContext()`.
+     *
+     * @note The size of the grid representing the tiled viewports can be accessed through `getTilesRows()` and `getTilesCols()`.
+     *
+     * @param objpos_map A (tag, pose) container to associate a 7-component `pose`, (x, y, z) position and a (ux, uy, uz, theta) axis-angle orientation, to a mesh with tag 'tag'.
+     * @param cam_x (x, y, z) position.
+     * @param cam_o (ux, uy, uz, theta) axis-angle orientation.
+     * @param pbo_index The index of the PBO where the pixel are stored.
+     *
+     * @return (true, PBO) upon success, (false, 0) otherswise.
+     **/
+    virtual bool superimpose(const std::vector<ModelPoseContainer>& objpos_multimap, const double* cam_x, const double* cam_o, const size_t pbo_index);
+
+    /**
+     * Render the mesh models in the pose specified in each element of `objpos_multimap` and move the virtual camera in
+     * `cam_x` position with orientation `cam_o`. Each group of meshes specified by the elements of `objpos_multimap` are rendered in a
+     * different viewport. Each viewport reports the mesh models as they are seen by the virtual camera.
+     * The method then stores the pixels of the viewports in the `pbo_index`-th Pixel Buffer Object (PBO) by tiling them in a regular grid.
+     *
+     * @note The size of the grid representing the tiled viewports can be accessed through `getTilesRows()` and `getTilesCols()`.
+     *
+     * @note `img` must be of size `cam_width * cam_height`, as specified during object construction, and the
+     * `SICAD::setBackgroundOpt(bool show_background)` must have been invoked with `true`.
+     *
+     * @param objpos_map A (tag, pose) container to associate a 7-component `pose`, (x, y, z) position and a (ux, uy, uz, theta) axis-angle orientation, to a mesh with tag 'tag'.
+     * @param cam_x (x, y, z) position.
+     * @param cam_o (ux, uy, uz, theta) axis-angle orientation.
+     * @param pbo_index The index of the PBO where the pixel are stored.
+     * @param img A background image.
+     *
+     * @return (true, PBO) upon success, (false, 0) otherswise.
+     **/
+    virtual bool superimpose(const std::vector<ModelPoseContainer>& objpos_multimap, const double* cam_x, const double* cam_o, const size_t pbo_index, const cv::Mat& img);
+
+    /**
+     * Make the current thread OpenGL context not current.
+     *
+     * @note This method must be called only when invoking `SICAD::superimpose()` working on Pixel Buffer Objects (PBO),
+     * before invoking again any `SICAD::superimpose()` methods (either the ones using PBOs or not), but after
+     * having used the PBO that otherwise cannot be accessed as they are bound to the current thread context.
+     */
+    virtual void releaseContext() const;
+
+    /**
+     * Returns the Pixel Buffer Object (PBO) vector and its size.
+     *
+     * @note Rendered pixels are stored in the `pbo_index`-th PBO and, in order to use it, the OpenGL context must remain current.
+     * As a consequence, once you are done working with the `pbo_index`-th PBO and before invoking again
+     * any other `SICAD::superimpose()` function, you must invoke `SICAD::releaseContext()`.
+     *
+     * @return (PBO base array address, number of PBOs)
+     */
+    std::pair<const GLuint*, size_t> getPBOs() const;
+
+    /**
+     * Returns `pbo_index`-th Pixel Buffer Object (PBO) value.
+     *
+     * @note Rendered pixels are stored in the `pbo_index`-th PBO and, in order to use it, the OpenGL context must remain current.
+     * As a consequence, once you are done working with the `pbo_index`-th PBO and before invoking again
+     * any other `SICAD::superimpose()` function, you must invoke `SICAD::releaseContext()`.
+     *
+     * @return (true, PBO) if `pbo_index` exists, (false, 0) otherwise.
+     */
+    std::pair<bool, GLuint> getPBO(const size_t pbo_index) const;
+
+    /**
+     * Sets the static transformation between the camera coordinate system and the OpenGL camera coordinate system.
+     *
+     * @param ogl_to_cam A 4-sized vector containing the axis-angle representation of the transformation.
+     */
+    void setOglToCam(const std::vector<float>& ogl_to_cam);
+
+    bool setProjectionMatrix(const GLsizei cam_width, const GLsizei cam_height, const GLfloat cam_fx, const GLfloat cam_fy, const GLfloat cam_cx, const GLfloat cam_cy);
+
+    bool getBackgroundOpt() const;
+
+    void setBackgroundOpt(bool show_background);
+
+    GLenum getWireframeOpt() const;
+
+    void setWireframeOpt(bool show_mesh_wires);
+
+    void setMipmapsOpt(const MIPMaps& mipmaps);
+
+    MIPMaps getMipmapsOpt() const;
+
+    int getTilesNumber() const;
+
+    int getTilesRows() const;
+
+    int getTilesCols() const;
+
+/* FIXME
+ * Change pointer with smartpointers.
+ */
+private:
+    static int class_counter_;
+
+    static GLsizei renderbuffer_size_;
+
+    const std::string log_ID_ = "[ROFT::SICAD]";
+
+    GLFWwindow* window_ = nullptr;
+
+    GLint tiles_num_ = 0;
+
+    GLsizei tiles_cols_ = 0;
+
+    GLsizei tiles_rows_ = 0;
+
+    GLsizei image_width_ = 0;
+
+    GLsizei image_height_ = 0;
+
+    GLfloat cam_fx_;
+
+    GLfloat cam_fy_;
+
+    GLfloat cam_cx_;
+
+    GLfloat cam_cy_;
+
+    glm::mat3 ogl_to_cam_ = glm::mat3(1.0f);
+
+    GLsizei framebuffer_width_ = 0;
+
+    GLsizei framebuffer_height_ = 0;
+
+    GLsizei tile_img_width_ = 0;
+
+    GLsizei tile_img_height_ = 0;
+
+    const GLfloat near_ = 0.001f;
+
+    const GLfloat far_ = 1000.0f;
+
+    std::thread::id main_thread_id_;
+
+    bool show_background_ = false;
+
+    GLenum  show_mesh_mode_ = GL_FILL;
+
+    MIPMaps mesh_mmaps_ = MIPMaps::nearest;
+
+    ROFT::SICADShader* shader_background_ = nullptr;
+
+    ROFT::SICADShader* shader_cad_ = nullptr;
+
+    std::unique_ptr<ROFT::SICADShader> shader_mesh_texture_;
+
+    ROFT::SICADShader* shader_frame_ = nullptr;
+
+    ModelContainer model_obj_;
+
+    GLuint fbo_;
+
+    GLuint texture_color_buffer_;
+
+	GLuint texture_depth_buffer_;
+
+    GLuint texture_depthtest_buffer_;
+
+    GLuint texture_background_;
+
+    GLuint vao_background_;
+
+    GLuint ebo_background_;
+
+    GLuint vbo_background_;
+
+    GLuint vao_frame_;
+
+    GLuint vbo_frame_;
+
+    size_t pbo_number_ = 2;
+
+    GLuint pbo_[2];
+
+    glm::mat4 back_proj_;
+
+    glm::mat4 projection_;
+
+    glm::mat4 getViewTransformationMatrix(const double* cam_x, const double* cam_o);
+
+    void pollOrPostEvent();
+
+    void renderBackground(const cv::Mat& img) const;
+
+    void setWireframe(GLenum mode);
+
+    void factorize_int(const GLsizei area, const GLsizei width_limit, const GLsizei height_limit, GLsizei& width, GLsizei& height);
+};
+
+#endif /* ROFT_SUPERIMPOSECAD_H */

--- a/src/roft-lib/include/ROFT/SICADModel.h
+++ b/src/roft-lib/include/ROFT/SICADModel.h
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2022 Istituto Italiano di Tecnologia (IIT)
+ *
+ * This software may be modified and distributed under the terms of the
+ * GPL-2+ license. See the accompanying LICENSE file for details.
+ *
+ *
+ * Part of this code is taken from https://github.com/robotology/superimpose-mesh-lib/commits/impl/depth
+ *
+ * This is the original BSD 3-Clause LICENSE the original code was provided with:
+ *
+ * Copyright (c) 2016-2019, Istituto Italiano di Tecnologia (IIT) All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+ * - Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ * - Neither the name of the organization nor the names of its contributors may be used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL CLAUDIO FANTACCI BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef ROFT_SICAD_MODEL_H
+#define ROFT_SICAD_MODEL_H
+
+#include <SuperimposeMesh/Model.h>
+
+#include <ROFT/SICADShader.h>
+
+#include <istream>
+
+namespace ROFT {
+    class SICADModel;
+}
+
+
+class ROFT::SICADModel
+{
+public:
+    SICADModel(const GLchar* path);
+
+    SICADModel(const std::basic_istream<char>* model_stream);
+
+    void Draw(ROFT::SICADShader shader);
+
+    bool has_texture();
+
+protected:
+    void loadModel(std::string path);
+
+    void loadModel(const std::basic_istream<char>* model_stream);
+
+    void processNode(aiNode* node, const aiScene* scene);
+
+    Mesh processMesh(aiMesh* mesh, const aiScene* scene);
+
+    GLint TextureFromFile(const char* path, std::string directory);
+
+    std::vector<Mesh::Texture> loadMaterialTextures(aiMaterial* mat, aiTextureType type, std::string typeName);
+
+private:
+    std::vector<Mesh> meshes_;
+
+    std::string directory_;
+
+    std::vector<Mesh::Texture> textures_loaded_;
+};
+
+#endif /* ROFT_SICAD_MODEL_H */

--- a/src/roft-lib/include/ROFT/SICADShader.h
+++ b/src/roft-lib/include/ROFT/SICADShader.h
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2022 Istituto Italiano di Tecnologia (IIT)
+ *
+ * This software may be modified and distributed under the terms of the
+ * GPL-2+ license. See the accompanying LICENSE file for details.
+ *
+ *
+ * Part of this code is taken from https://github.com/robotology/superimpose-mesh-lib/commits/impl/depth
+ *
+ * This is the original BSD 3-Clause LICENSE the original code was provided with:
+ *
+ * Copyright (c) 2016-2019, Istituto Italiano di Tecnologia (IIT) All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+ * - Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ * - Neither the name of the organization nor the names of its contributors may be used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL CLAUDIO FANTACCI BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef ROFT_SICAD_SHADER_H
+#define ROFT_SICAD_SHADER_H
+
+#include <exception>
+#include <string>
+
+#include <GL/glew.h>
+
+namespace ROFT {
+    class SICADShader;
+}
+
+
+class ROFT::SICADShader
+{
+public:
+    /**
+     * Create a shader program with given vertex and fragment shader paths.
+     */
+    SICADShader(const std::string& vertex_shader_path, const std::string& fragment_shader_path);
+
+    /**
+     * Activate the shader program.
+     */
+    void install();
+
+    /**
+     * Deactivate the shader program.
+     */
+    void uninstall();
+
+
+    inline const GLuint get_program()
+    {
+        return shader_program_id_;
+    }
+
+private:
+    /**
+     * The program ID.
+     */
+    GLuint shader_program_id_;
+};
+
+#endif /* ROFT_SICAD_SHADER_H */

--- a/src/roft-lib/shader/shader_background.frag
+++ b/src/roft-lib/shader/shader_background.frag
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2022 Istituto Italiano di Tecnologia (IIT)
+ *
+ * This software may be modified and distributed under the terms of the
+ * GPL-2+ license. See the accompanying LICENSE file for details.
+ *
+ *
+ * Part of this code is taken from https://github.com/robotology/superimpose-mesh-lib/commits/impl/depth
+ *
+ * This is the original BSD 3-Clause LICENSE the original code was provided with:
+ *
+ * Copyright (c) 2016-2019, Istituto Italiano di Tecnologia (IIT) All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+ * - Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ * - Neither the name of the organization nor the names of its contributors may be used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL CLAUDIO FANTACCI BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#version 330 core
+
+in vec3 ourColor;
+in vec2 TexCoord;
+
+out vec4 color;
+
+uniform sampler2D ourTexture;
+
+void main()
+{
+    color = texture(ourTexture, TexCoord);
+}

--- a/src/roft-lib/shader/shader_background.vert
+++ b/src/roft-lib/shader/shader_background.vert
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2022 Istituto Italiano di Tecnologia (IIT)
+ *
+ * This software may be modified and distributed under the terms of the
+ * GPL-2+ license. See the accompanying LICENSE file for details.
+ *
+ *
+ * Part of this code is taken from https://github.com/robotology/superimpose-mesh-lib/commits/impl/depth
+ *
+ * This is the original BSD 3-Clause LICENSE the original code was provided with:
+ *
+ * Copyright (c) 2016-2019, Istituto Italiano di Tecnologia (IIT) All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+ * - Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ * - Neither the name of the organization nor the names of its contributors may be used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL CLAUDIO FANTACCI BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#version 330 core
+
+layout (location = 0) in vec2 position;
+layout (location = 1) in vec3 color;
+layout (location = 2) in vec2 texCoord;
+
+out vec3 ourColor;
+out vec2 TexCoord;
+
+uniform mat4 projection;
+
+void main()
+{
+    gl_Position = projection * vec4(position, -99999.99, 1.0f);
+    ourColor = color;
+    TexCoord = vec2(texCoord.x, 1.0f - texCoord.y);
+}

--- a/src/roft-lib/shader/shader_frame.frag
+++ b/src/roft-lib/shader/shader_frame.frag
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2022 Istituto Italiano di Tecnologia (IIT)
+ *
+ * This software may be modified and distributed under the terms of the
+ * GPL-2+ license. See the accompanying LICENSE file for details.
+ *
+ *
+ * Part of this code is taken from https://github.com/robotology/superimpose-mesh-lib/commits/impl/depth
+ *
+ * This is the original BSD 3-Clause LICENSE the original code was provided with:
+ *
+ * Copyright (c) 2016-2019, Istituto Italiano di Tecnologia (IIT) All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+ * - Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ * - Neither the name of the organization nor the names of its contributors may be used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL CLAUDIO FANTACCI BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#version 330 core
+
+in vec3 vert_color;
+
+out vec4 frag_color;
+
+void main()
+{
+    frag_color = vec4(vert_color, 1.0f);
+}

--- a/src/roft-lib/shader/shader_frame.vert
+++ b/src/roft-lib/shader/shader_frame.vert
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2022 Istituto Italiano di Tecnologia (IIT)
+ *
+ * This software may be modified and distributed under the terms of the
+ * GPL-2+ license. See the accompanying LICENSE file for details.
+ *
+ *
+ * Part of this code is taken from https://github.com/robotology/superimpose-mesh-lib/commits/impl/depth
+ *
+ * This is the original BSD 3-Clause LICENSE the original code was provided with:
+ *
+ * Copyright (c) 2016-2019, Istituto Italiano di Tecnologia (IIT) All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+ * - Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ * - Neither the name of the organization nor the names of its contributors may be used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL CLAUDIO FANTACCI BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#version 330 core
+
+layout (location = 0) in vec3 position;
+layout (location = 1) in vec3 color;
+
+out vec3 vert_color;
+
+uniform mat4 model;
+uniform mat4 view;
+uniform mat4 projection;
+
+void main()
+{
+    gl_Position = projection * view * model * vec4(position, 1.0f);
+    vert_color = color;
+}

--- a/src/roft-lib/shader/shader_model.frag
+++ b/src/roft-lib/shader/shader_model.frag
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2022 Istituto Italiano di Tecnologia (IIT)
+ *
+ * This software may be modified and distributed under the terms of the
+ * GPL-2+ license. See the accompanying LICENSE file for details.
+ *
+ *
+ * Part of this code is taken from https://github.com/robotology/superimpose-mesh-lib/commits/impl/depth
+ *
+ * This is the original BSD 3-Clause LICENSE the original code was provided with:
+ *
+ * Copyright (c) 2016-2019, Istituto Italiano di Tecnologia (IIT) All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+ * - Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ * - Neither the name of the organization nor the names of its contributors may be used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL CLAUDIO FANTACCI BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#version 330 core
+
+layout (location = 0) out vec4 color;
+layout (location = 1) out float depth;
+
+float near = 0.001f;
+float far = 1000.0f;
+
+float linearize_depth(float coord_z)
+{
+    /* Back to NDC. */
+    float z = coord_z * 2.0 - 1.0;
+
+    /* Evaluate real depth. */
+    return (2.0 * near * far) / (far + near - z * (far - near));
+}
+
+void main()
+{
+    /* BGR orange-like color. */
+    color = vec4(0.2f, 0.5f, 1.0f, 1.0f);
+
+    /* Real depth. */
+    depth = linearize_depth(gl_FragCoord.z);
+}

--- a/src/roft-lib/shader/shader_model.vert
+++ b/src/roft-lib/shader/shader_model.vert
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2022 Istituto Italiano di Tecnologia (IIT)
+ *
+ * This software may be modified and distributed under the terms of the
+ * GPL-2+ license. See the accompanying LICENSE file for details.
+ *
+ *
+ * Part of this code is taken from https://github.com/robotology/superimpose-mesh-lib/commits/impl/depth
+ *
+ * This is the original BSD 3-Clause LICENSE the original code was provided with:
+ *
+ * Copyright (c) 2016-2019, Istituto Italiano di Tecnologia (IIT) All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+ * - Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ * - Neither the name of the organization nor the names of its contributors may be used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL CLAUDIO FANTACCI BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#version 330 core
+
+layout (location = 0) in vec3 position;
+layout (location = 1) in vec3 normal;
+layout (location = 2) in vec2 texCoords;
+
+out vec2 TexCoords;
+
+uniform mat4 model;
+uniform mat4 view;
+uniform mat4 projection;
+
+void main()
+{
+    gl_Position = projection * view * model * vec4(position, 1.0f);
+    TexCoords = texCoords;
+}

--- a/src/roft-lib/shader/shader_model_texture.frag
+++ b/src/roft-lib/shader/shader_model_texture.frag
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2022 Istituto Italiano di Tecnologia (IIT)
+ *
+ * This software may be modified and distributed under the terms of the
+ * GPL-2+ license. See the accompanying LICENSE file for details.
+ *
+ *
+ * Part of this code is taken from https://github.com/robotology/superimpose-mesh-lib/commits/impl/depth
+ *
+ * This is the original BSD 3-Clause LICENSE the original code was provided with:
+ *
+ * Copyright (c) 2016-2019, Istituto Italiano di Tecnologia (IIT) All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+ * - Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ * - Neither the name of the organization nor the names of its contributors may be used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL CLAUDIO FANTACCI BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#version 330 core
+
+in vec2 TexCoords;
+
+out vec4 color;
+
+uniform sampler2D texture_diffuse1;
+
+void main()
+{
+     color = texture(texture_diffuse1, TexCoords);
+}

--- a/src/roft-lib/src/SICAD.cpp
+++ b/src/roft-lib/src/SICAD.cpp
@@ -1,0 +1,1800 @@
+/*
+ * Copyright (C) 2022 Istituto Italiano di Tecnologia (IIT)
+ *
+ * This software may be modified and distributed under the terms of the
+ * GPL-2+ license. See the accompanying LICENSE file for details.
+ *
+ *
+ * Part of this code is taken from https://github.com/robotology/superimpose-mesh-lib/commits/impl/depth
+ *
+ * This is the original BSD 3-Clause LICENSE the original code was provided with:
+ *
+ * Copyright (c) 2016-2019, Istituto Italiano di Tecnologia (IIT) All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+ * - Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ * - Neither the name of the organization nor the names of its contributors may be used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL CLAUDIO FANTACCI BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <ROFT/SICAD.h>
+
+#include <iostream>
+#include <exception>
+#include <string>
+
+#include <assimp/Importer.hpp>
+#include <assimp/scene.h>
+#include <assimp/postprocess.h>
+
+#include <glm/gtc/matrix_transform.hpp>
+#include <glm/gtc/type_ptr.hpp>
+
+#include <opencv2/imgproc/imgproc.hpp>
+
+using namespace ROFT;
+
+int SICAD::class_counter_ = 0;
+GLsizei SICAD::renderbuffer_size_ = 0;
+
+
+SICAD::SICAD
+(
+    const ModelPathContainer& objfile_map,
+    const GLsizei cam_width,
+    const GLsizei cam_height,
+    const GLfloat cam_fx,
+    const GLfloat cam_fy,
+    const GLfloat cam_cx,
+    const GLfloat cam_cy
+) :
+    SICAD(cam_width, cam_height, cam_fx, cam_fy, cam_cx, cam_cy, 1, "__prc/shader", { 1.0f, 0.0f, 0.0f, 0.0f }, objfile_map)
+{ }
+
+
+SICAD::SICAD
+(
+    const ModelStreamContainer& objstream_map,
+    const GLsizei cam_width,
+    const GLsizei cam_height,
+    const GLfloat cam_fx,
+    const GLfloat cam_fy,
+    const GLfloat cam_cx,
+    const GLfloat cam_cy
+) :
+    SICAD(cam_width, cam_height, cam_fx, cam_fy, cam_cx, cam_cy, 1, "__prc/shader", { 1.0f, 0.0f, 0.0f, 0.0f }, ModelPathContainer(), objstream_map)
+{ }
+
+
+SICAD::SICAD
+(
+    const ModelPathContainer& objfile_map,
+    const GLsizei cam_width,
+    const GLsizei cam_height,
+    const GLfloat cam_fx,
+    const GLfloat cam_fy,
+    const GLfloat cam_cx,
+    const GLfloat cam_cy,
+    const GLint num_images
+) :
+    SICAD(cam_width, cam_height, cam_fx, cam_fy, cam_cx, cam_cy, num_images, "__prc/shader", { 1.0f, 0.0f, 0.0f, 0.0f }, objfile_map)
+{ }
+
+
+SICAD::SICAD
+(
+    const ModelStreamContainer& objstream_map,
+    const GLsizei cam_width,
+    const GLsizei cam_height,
+    const GLfloat cam_fx,
+    const GLfloat cam_fy,
+    const GLfloat cam_cx,
+    const GLfloat cam_cy,
+    const GLint num_images
+) :
+    SICAD(cam_width, cam_height, cam_fx, cam_fy, cam_cx, cam_cy, num_images, "__prc/shader", { 1.0f, 0.0f, 0.0f, 0.0f }, ModelPathContainer(), objstream_map)
+{ }
+
+
+SICAD::SICAD
+(
+    const ModelPathContainer& objfile_map,
+    const GLsizei cam_width,
+    const GLsizei cam_height,
+    const GLfloat cam_fx,
+    const GLfloat cam_fy,
+    const GLfloat cam_cx,
+    const GLfloat cam_cy,
+    const GLint num_images,
+    const std::string& shader_folder
+) :
+    SICAD(cam_width, cam_height, cam_fx, cam_fy, cam_cx, cam_cy, num_images, shader_folder, { 1.0f, 0.0f, 0.0f, 0.0f }, objfile_map)
+{ }
+
+
+SICAD::SICAD
+(
+    const GLsizei cam_width,
+    const GLsizei cam_height,
+    const GLfloat cam_fx,
+    const GLfloat cam_fy,
+    const GLfloat cam_cx,
+    const GLfloat cam_cy,
+    const GLint num_images,
+    const std::string& shader_folder,
+    const std::vector<float>& ogl_to_cam,
+    const ModelPathContainer& objfile_map,
+    const ModelStreamContainer& objstream_map
+) :
+    cam_fx_(cam_fx),
+    cam_fy_(cam_fy),
+    cam_cx_(cam_cx),
+    cam_cy_(cam_cy)
+{
+    if (ogl_to_cam.size() != 4)
+        throw std::runtime_error("ERROR::SICAD::CTOR\nERROR:\n\tWrong size provided for ogl_to_cam.\n\tShould be 4, was given " + std::to_string(ogl_to_cam.size()) + ".");
+
+
+    std::cout << log_ID_ << "Start setting up OpenGL rendering facilities." << std::endl;
+
+
+    /* Initialize GLFW. */
+    if (glfwInit() == GL_FALSE)
+        throw std::runtime_error("ERROR::SICAD::CTOR\nERROR:\n\tFailed to initialize GLFW.");
+
+
+    /* Set context properties by "hinting" specific (property, value) pairs. */
+    glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 3);
+    glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 3);
+    glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
+    glfwWindowHint(GLFW_RESIZABLE, GL_FALSE);
+    glfwWindowHint(GLFW_VISIBLE, GL_FALSE);
+    glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GL_TRUE);
+    glfwWindowHint(GLFW_CONTEXT_RELEASE_BEHAVIOR, GLFW_RELEASE_BEHAVIOR_NONE);
+#ifdef GLFW_MAC
+    glfwWindowHint(GLFW_COCOA_RETINA_FRAMEBUFFER, GL_FALSE);
+#endif
+
+
+    /* Create window to create context and enquire OpenGL for the maximum size of the renderbuffer */
+    window_ = glfwCreateWindow(1, 1, "OpenGL window", nullptr, nullptr);
+    if (window_ == nullptr)
+    {
+        glfwTerminate();
+        throw std::runtime_error("ERROR::SICAD::CTOR\nERROR:\n\tFailed to create GLFW window.");
+    }
+
+    /* Make the OpenGL context of window the current one handled by this thread. */
+    glfwMakeContextCurrent(window_);
+
+
+    /* Enquire GPU for maximum renderbuffer size (both width and height) of the default framebuffer */
+    glGetIntegerv(GL_MAX_RENDERBUFFER_SIZE, &renderbuffer_size_);
+    std::cout << log_ID_ << "Max renderbuffer size is " + std::to_string(renderbuffer_size_) + "x" + std::to_string(renderbuffer_size_) + " size." << std::endl;
+
+
+    /* Given image size */
+    image_width_ = cam_width;
+    image_height_ = cam_height;
+    std::cout << log_ID_ << "Given image size " + std::to_string(image_width_) + "x" + std::to_string(image_height_) + "." << std::endl;
+
+
+    /* Compute the maximum number of images that can be rendered conditioned on the maximum renderbuffer size */
+    factorize_int(num_images, std::floor(renderbuffer_size_ / image_width_), std::floor(renderbuffer_size_ / image_height_), tiles_cols_, tiles_rows_);
+    tiles_num_ = tiles_rows_ * tiles_cols_;
+    std::cout << log_ID_ << "Required to render " + std::to_string(num_images) + " image(s)." << std::endl;
+    std::cout << log_ID_ << "Allowed number or rendered images is " + std::to_string(tiles_num_) + " (" + std::to_string(tiles_rows_) + "x" + std::to_string(tiles_cols_) + " grid)." << std::endl;
+
+    /* Set framebuffer size. */
+    framebuffer_width_ = image_width_ * tiles_cols_;
+    framebuffer_height_ = image_height_ * tiles_rows_;
+
+    /* Set rendered image size. May vary in HDPI monitors. */
+    tile_img_width_ = framebuffer_width_ / tiles_cols_;
+    tile_img_height_ = framebuffer_height_ / tiles_rows_;
+    std::cout << log_ID_ << "The rendered image size is " + std::to_string(tile_img_width_) + "x" + std::to_string(tile_img_height_) + "." << std::endl;
+
+
+    /* Initialize GLEW to use the OpenGL implementation provided by the videocard manufacturer. */
+    glewExperimental = GL_TRUE;
+    if (glewInit() != GLEW_OK)
+        throw std::runtime_error("ERROR::SICAD::CTOR\nERROR:\n\tFailed to initialize GLEW.");
+
+    /* Swap buffers immediately when calling glfwSwapBuffers, without waiting for a refresh. */
+    glfwSwapInterval(0);
+
+    /* Set GL property. */
+    glfwPollEvents();
+    main_thread_id_ = std::this_thread::get_id();
+
+
+    std::cout << log_ID_ << "Succesfully set up OpenGL facilities!" << std::endl;
+
+
+    std::cout << log_ID_ << "Setting up OpenGL shaders, buffers and textures." << std::endl;
+
+
+    /* Rotation from real camera to OpenGL frame */
+    ogl_to_cam_ = glm::mat3(glm::rotate(glm::mat4(1.0f), ogl_to_cam[3], glm::make_vec3(ogl_to_cam.data())));
+
+
+	/* Create a framebuffer object. */
+    glGenFramebuffers(1, &fbo_);
+    glBindFramebuffer(GL_FRAMEBUFFER, fbo_);
+
+	/* Create a framebuffer color texture. */
+    glGenTextures(1, &texture_color_buffer_);
+    glBindTexture(GL_TEXTURE_2D, texture_color_buffer_);
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, framebuffer_width_, framebuffer_height_, 0, GL_RGB, GL_UNSIGNED_BYTE, NULL);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST_MIPMAP_NEAREST);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+    glBindTexture(GL_TEXTURE_2D, 0);
+
+    glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, texture_color_buffer_, 0);
+
+	/* Create a framebuffer depth texture. */
+	glGenTextures(1, &texture_depth_buffer_);
+	glBindTexture(GL_TEXTURE_2D, texture_depth_buffer_);
+	glTexImage2D(GL_TEXTURE_2D, 0, GL_R32F, framebuffer_width_, framebuffer_height_, 0, GL_RED, GL_FLOAT, NULL);
+	//glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST_MIPMAP_NEAREST);
+	//glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+	glBindTexture(GL_TEXTURE_2D, 0);
+
+	glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT1, GL_TEXTURE_2D, texture_depth_buffer_, 0);
+
+	/* Instruct OpenGL to render to both framebuffer color attachments. */
+	unsigned int attachments[3] = { GL_COLOR_ATTACHMENT0, GL_COLOR_ATTACHMENT1 };
+	glDrawBuffers(2, attachments);
+
+    /* Create a framebuffer depth texture for depth test. */
+    glGenTextures(1, &texture_depthtest_buffer_);
+    glBindTexture(GL_TEXTURE_2D, texture_depthtest_buffer_);
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_DEPTH_COMPONENT, framebuffer_width_, framebuffer_height_, 0, GL_DEPTH_COMPONENT, GL_UNSIGNED_BYTE, NULL);
+    glBindTexture(GL_TEXTURE_2D, 0);
+
+    glFramebufferTexture2D(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_TEXTURE_2D, texture_depthtest_buffer_, 0);
+
+    /* Check whether the framebuffer has been completely created or not. */
+    if (glCheckFramebufferStatus(GL_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE)
+        throw std::runtime_error("ERROR::SICAD::CTOR::\nERROR:\n\tCustom framebuffer could not be created.");
+
+
+    /* Enable depth and scissor test. */
+    glEnable(GL_DEPTH_TEST);
+    glEnable(GL_SCISSOR_TEST);
+
+
+    /* Unbind framebuffer. */
+    glBindFramebuffer(GL_FRAMEBUFFER, 0);
+
+
+    /* Crate the vertices for 3D reference frame. */
+    glGenVertexArrays(1, &vao_frame_);
+    glBindVertexArray(vao_frame_);
+
+    glGenBuffers(1, &vbo_frame_);
+    glBindBuffer(GL_ARRAY_BUFFER, vbo_frame_);
+
+    GLfloat vert_frame[] = {// Positions       // Colors
+                            0.0f, 0.0f, 0.0f,  1.0f, 0.0f, 0.0f,   // Origin X
+                            0.1f, 0.0f, 0.0f,  1.0f, 0.0f, 0.0f,   // End X
+                            0.0f, 0.0f, 0.0f,  0.0f, 1.0f, 0.0f,   // Origin Y
+                            0.0f, 0.1f, 0.0f,  0.0f, 1.0f, 0.0f,   // End Y
+                            0.0f, 0.0f, 0.0f,  0.0f, 0.0f, 1.0f,   // Origin Z
+                            0.0f, 0.0f, 0.1f,  0.0f, 0.0f, 1.0f }; // End Z
+
+    glBufferData(GL_ARRAY_BUFFER, sizeof(vert_frame), vert_frame, GL_STATIC_DRAW);
+
+    glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, 6 * sizeof(GLfloat), (GLvoid*)(0));
+    glVertexAttribPointer(1, 3, GL_FLOAT, GL_FALSE, 6 * sizeof(GLfloat), (GLvoid*)(3 * sizeof(GLfloat)));
+
+    glEnableVertexAttribArray(0);
+    glEnableVertexAttribArray(1);
+
+    glBindVertexArray(0);
+
+
+    /* Create a background texture. */
+    glGenTextures(1, &texture_background_);
+
+    /* Crate the squared support for the backround texture. */
+    glGenVertexArrays(1, &vao_background_);
+    glBindVertexArray(vao_background_);
+
+    glGenBuffers(1, &vbo_background_);
+    glBindBuffer(GL_ARRAY_BUFFER, vbo_background_);
+
+    GLfloat vert_background[] = {// Positions    // Colors            // Texture Coords
+                                    1.0f,  1.0f,    1.0f, 0.0f, 0.0f,    1.0f, 1.0f,   // Top Right
+                                    1.0f, -1.0f,    0.0f, 1.0f, 0.0f,    1.0f, 0.0f,   // Bottom Right
+                                   -1.0f, -1.0f,    0.0f, 0.0f, 1.0f,    0.0f, 0.0f,   // Bottom Left
+                                   -1.0f,  1.0f,    1.0f, 1.0f, 0.0f,    0.0f, 1.0f }; // Top Left
+
+    glBufferData(GL_ARRAY_BUFFER, sizeof(vert_background), vert_background, GL_STATIC_DRAW);
+
+    glGenBuffers(1, &ebo_background_);
+    glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, ebo_background_);
+
+    GLuint indices[] = { 0, 1, 3,   // First Triangle
+                         1, 2, 3 }; // Second Triangle
+
+    glBufferData(GL_ELEMENT_ARRAY_BUFFER, sizeof(indices), indices, GL_STATIC_DRAW);
+
+    glVertexAttribPointer(0, 2, GL_FLOAT, GL_FALSE, 7 * sizeof(GLfloat), (GLvoid*)(0));
+    glVertexAttribPointer(1, 3, GL_FLOAT, GL_FALSE, 7 * sizeof(GLfloat), (GLvoid*)(2 * sizeof(GLfloat)));
+    glVertexAttribPointer(2, 2, GL_FLOAT, GL_FALSE, 7 * sizeof(GLfloat), (GLvoid*)(5 * sizeof(GLfloat)));
+
+    glEnableVertexAttribArray(0);
+    glEnableVertexAttribArray(1);
+    glEnableVertexAttribArray(2);
+
+    glBindVertexArray(0);
+
+
+    /* Crate the Pixel Buffer Objects for reading rendered images and manipulate data directly on GPU. */
+    glGenBuffers(2, pbo_);
+    unsigned int number_of_channel = 3;
+
+    glBindBuffer(GL_PIXEL_PACK_BUFFER, pbo_[0]);
+    glBufferData(GL_PIXEL_PACK_BUFFER, framebuffer_width_ * framebuffer_height_ * number_of_channel, 0, GL_STREAM_READ);
+
+    glBindBuffer(GL_PIXEL_PACK_BUFFER, pbo_[1]);
+    glBufferData(GL_PIXEL_PACK_BUFFER, framebuffer_width_ * framebuffer_height_ * number_of_channel, 0, GL_STREAM_READ);
+
+    glBindBuffer(GL_PIXEL_PACK_BUFFER, 0);
+
+    /* FIXME
+     * Delete std::nothrow and change try-catch logic.
+     */
+    /* FIXME
+     * Add std::make_unique in an utility header.
+     */
+    /* Crate background shader program. */
+    std::cout << log_ID_ << "Setting up background shader." << std::endl;
+
+    try
+    {
+        shader_background_ = new (std::nothrow) SICADShader((shader_folder + "/shader_background.vert").c_str(), (shader_folder + "/shader_background.frag").c_str());
+    }
+    catch (const std::runtime_error& e)
+    {
+        throw std::runtime_error(e.what());
+    }
+    if (shader_background_ == nullptr)
+        throw std::runtime_error("ERROR::SICAD::CTOR\nERROR:\n\tBackground shader source file not found!");
+
+    std::cout << log_ID_ << "Background shader succesfully set up!" << std::endl;
+
+
+    /* Crate shader program for mesh model. */
+    std::cout << log_ID_ << "Setting up shader for mesh models." << std::endl;
+
+    try
+    {
+        shader_cad_ = new (std::nothrow) SICADShader((shader_folder + "/shader_model.vert").c_str(), (shader_folder + "/shader_model.frag").c_str());
+    }
+    catch (const std::runtime_error& e)
+    {
+        throw std::runtime_error(e.what());
+    }
+    if (shader_cad_ == nullptr)
+        throw std::runtime_error("ERROR::SICAD::CTOR\nERROR:\n\t3D model shader source file not found!");
+
+    std::cout << log_ID_ << "Shader for mesh models succesfully set up!" << std::endl;
+
+
+    /* Crate shader program for textured model. */
+    std::cout << log_ID_ << "Setting up shader for textured mesh model." << std::endl;
+
+    try
+    {
+        shader_mesh_texture_ = std::unique_ptr<SICADShader>(new SICADShader((shader_folder + "/shader_model.vert").c_str(), (shader_folder + "/shader_model_texture.frag").c_str()));
+    }
+    catch (const std::runtime_error& e)
+    {
+        throw std::runtime_error("ERROR::SICAD::CTOR\nERROR:\n\tFailed to create shader program for textured meshes.\n" + std::string(e.what()));
+    }
+
+    std::cout << log_ID_ << "Shader for textured mesh models succesfully set up!" << std::endl;
+
+
+    /* Crate axis frame shader program. */
+    std::cout << log_ID_ << "Setting up maxis frame shader." << std::endl;
+
+    try
+    {
+        shader_frame_ = new (std::nothrow) SICADShader((shader_folder + "/shader_frame.vert").c_str(), (shader_folder + "/shader_frame.frag").c_str());
+    }
+    catch (const std::runtime_error& e)
+    {
+        throw std::runtime_error(e.what());
+    }
+    if (shader_frame_ == nullptr)
+        throw std::runtime_error("ERROR::SICAD::CTOR\nERROR:\n\tAxis frame shader source file not found!");
+
+    std::cout << log_ID_ << "Axis frame shader succesfully set up!" << std::endl;
+
+
+    /* Load models from file streams, if any. */
+    for (const ModelStreamElement& pair : objstream_map)
+    {
+        auto search = model_obj_.find(pair.first);
+        if(search == model_obj_.end())
+        {
+            std::cout << log_ID_ << "Loading " + pair.first + " model for OpenGL rendering from stream." << std::endl;
+
+            model_obj_[pair.first] = new (std::nothrow) SICADModel(pair.second);
+
+            if (model_obj_[pair.first] == nullptr)
+                throw std::runtime_error("ERROR::SICAD::CTOR\nERROR:\n\t" + pair.first + " model cannot be loaded from stream!");
+        }
+        else
+        {
+            std::cout << log_ID_ << "Skipping " + pair.first + " model for OpenGL rendering. Object name already exists." << std::endl;
+            std::cout << log_ID_ << "If you want to update " + pair.first + " model for OpenGL rendering, use the updateModel function." << std::endl;
+        }
+    }
+
+    /* Load models from file paths, if any. */
+    for (const ModelPathElement& pair : objfile_map)
+    {
+        auto search = model_obj_.find(pair.first);
+        if(search == model_obj_.end())
+        {
+            std::cout << log_ID_ << "Loading " + pair.first + " model for OpenGL rendering from " << pair.second << "." << std::endl;
+
+            model_obj_[pair.first] = new (std::nothrow) SICADModel(pair.second.c_str());
+
+            if (model_obj_[pair.first] == nullptr)
+                throw std::runtime_error("ERROR::SICAD::CTOR\nERROR:\n\t" + pair.first + " model file from " + pair.second + " not found!");
+        }
+        else
+        {
+            std::cout << log_ID_ << "Skipping " + pair.first + " model for OpenGL rendering. Object name already exists." << std::endl;
+            std::cout << log_ID_ << "If you want to update " + pair.first + " model for OpenGL rendering, use the updateModel function." << std::endl;
+        }
+    }
+
+    back_proj_ = glm::ortho(-1.001f, 1.001f, -1.001f, 1.001f, 0.0f, far_*100.f);
+
+    glfwMakeContextCurrent(nullptr);
+
+
+    std::cout << log_ID_ << "Succesfully set up OpenGL shaders, buffers and textures." << std::endl;
+
+
+    /* Set projection matrix */
+    std::cout << log_ID_ << "Setting up projection matrix." << std::endl;
+
+    if (!setProjectionMatrix(cam_width, cam_height, cam_fx, cam_fy, cam_cx, cam_cy))
+        throw std::runtime_error("ERROR::SICAD::CTOR\nERROR:\n\tFailed to set projection matrix.");
+
+
+    /* Increase static class counter. */
+    ++class_counter_;
+
+
+    std::cout << log_ID_ << "Initialization completed!" << std::endl;
+}
+
+
+SICAD::~SICAD()
+{
+    std::cout << log_ID_ << "Deallocating OpenGL resources..." << std::endl;
+
+
+    glfwMakeContextCurrent(window_);
+
+
+    for (const ModelElement& pair : model_obj_)
+    {
+        std::cout << log_ID_ << "Deleting OpenGL "+ pair.first+" model." << std::endl;
+        delete pair.second;
+    }
+
+
+	glDeleteTextures(1, &texture_color_buffer_);
+	glDeleteTextures(1, &texture_depth_buffer_);
+    glDeleteTextures(1, &texture_depthtest_buffer_);
+    glDeleteFramebuffers(1, &fbo_);
+    glDeleteVertexArrays(1, &vao_background_);
+    glDeleteBuffers(1, &ebo_background_);
+    glDeleteBuffers(1, &vbo_background_);
+    glDeleteVertexArrays(1, &vao_frame_);
+    glDeleteBuffers(1, &vbo_frame_);
+    glDeleteTextures(1, &texture_background_);
+    glDeleteBuffers(2, pbo_);
+
+
+    std::cout << log_ID_ << "Deleting OpenGL shaders." << std::endl;
+    delete shader_background_;
+    delete shader_cad_;
+    delete shader_frame_;
+
+
+    std::cout << log_ID_ << "Closing OpenGL window/context." << std::endl;
+    glfwSetWindowShouldClose(window_, GL_TRUE);
+    glfwMakeContextCurrent(nullptr);
+
+
+    class_counter_--;
+    if (class_counter_ == 0)
+    {
+        std::cout << log_ID_ << "Terminating GLFW." << std::endl;
+        glfwTerminate();
+    }
+
+
+    std::cout << log_ID_ << "OpenGL resource deallocation completed!" << std::endl;
+}
+
+
+bool SICAD::getOglWindowShouldClose()
+{
+    return (glfwWindowShouldClose(window_) == GL_TRUE ? true : false);
+}
+
+
+void SICAD::setOglWindowShouldClose(bool should_close)
+{
+    glfwSetWindowShouldClose(window_, GL_TRUE);
+
+    pollOrPostEvent();
+}
+
+
+bool SICAD::superimpose
+(
+    const ModelPoseContainer& objpos_map,
+    const double* cam_x,
+    const double* cam_o,
+    cv::Mat& img
+)
+{
+    glfwMakeContextCurrent(window_);
+
+    glBindFramebuffer(GL_FRAMEBUFFER, fbo_);
+
+    /* Render in the upper-left-most tile of the render grid */
+    glViewport(0,               framebuffer_height_ - tile_img_height_,
+               tile_img_width_, tile_img_height_                       );
+    glScissor (0,               framebuffer_height_ - tile_img_height_,
+               tile_img_width_, tile_img_height_                       );
+
+    /* Clear the colorbuffer. */
+    glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
+    glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+
+    /* Draw the background picture. */
+    if (getBackgroundOpt())
+        renderBackground(img);
+
+    /* View mesh filled or as wireframe. */
+    setWireframe(getWireframeOpt());
+
+    /* View transformation matrix. */
+    glm::mat4 view = getViewTransformationMatrix(cam_x, cam_o);
+
+    /* Install/Use the program specified by the shader. */
+    shader_cad_->install();
+    glUniformMatrix4fv(glGetUniformLocation(shader_cad_->get_program(), "view"), 1, GL_FALSE, glm::value_ptr(view));
+    shader_cad_->uninstall();
+
+    shader_mesh_texture_->install();
+    glUniformMatrix4fv(glGetUniformLocation(shader_mesh_texture_->get_program(), "view"), 1, GL_FALSE, glm::value_ptr(view));
+    shader_mesh_texture_->uninstall();
+
+    shader_frame_->install();
+    glUniformMatrix4fv(glGetUniformLocation(shader_frame_->get_program(), "view"), 1, GL_FALSE, glm::value_ptr(view));
+    shader_frame_->uninstall();
+
+    /* Model transformation matrix. */
+    for (const ModelPoseContainerElement& pair : objpos_map)
+    {
+        const double* pose = pair.second.data();
+
+        glm::mat4 model = glm::rotate(glm::mat4(1.0f), static_cast<float>(pose[6]), glm::vec3(static_cast<float>(pose[3]), static_cast<float>(pose[4]), static_cast<float>(pose[5])));
+        model[3][0] = pose[0];
+        model[3][1] = pose[1];
+        model[3][2] = pose[2];
+
+        auto iter_model = model_obj_.find(pair.first);
+        if (iter_model != model_obj_.end())
+        {
+            if ((iter_model->second)->has_texture())
+            {
+                shader_mesh_texture_->install();
+                glUniformMatrix4fv(glGetUniformLocation(shader_mesh_texture_->get_program(), "model"), 1, GL_FALSE, glm::value_ptr(model));
+
+                (iter_model->second)->Draw(*shader_mesh_texture_);
+
+                shader_mesh_texture_->uninstall();
+            }
+            else
+            {
+                shader_cad_->install();
+                glUniformMatrix4fv(glGetUniformLocation(shader_cad_->get_program(), "model"), 1, GL_FALSE, glm::value_ptr(model));
+
+                (iter_model->second)->Draw(*shader_cad_);
+
+                shader_cad_->uninstall();
+            }
+        }
+        else if (pair.first == "frame")
+        {
+            shader_frame_->install();
+            glUniformMatrix4fv(glGetUniformLocation(shader_frame_->get_program(), "model"), 1, GL_FALSE, glm::value_ptr(model));
+            glBindVertexArray(vao_frame_);
+            glDrawArrays(GL_LINES, 0, 6);
+            glBindVertexArray(0);
+            shader_frame_->uninstall();
+        }
+    }
+
+    /* Read before swap. glReadPixels read the current framebuffer, i.e. the back one. */
+    /* See: http://stackoverflow.com/questions/16809833/opencv-image-loading-for-opengl-texture#16812529
+       and http://stackoverflow.com/questions/9097756/converting-data-from-glreadpixels-to-opencvmat#9098883 */
+    cv::Mat ogl_pixel(framebuffer_height_ / tiles_rows_, framebuffer_width_ / tiles_cols_, CV_8UC3);
+    glReadBuffer(GL_COLOR_ATTACHMENT0);
+    glPixelStorei(GL_PACK_ALIGNMENT, (ogl_pixel.step & 3) ? 1 : 4);
+    glPixelStorei(GL_PACK_ROW_LENGTH, ogl_pixel.step/ogl_pixel.elemSize());
+    glReadPixels(0, framebuffer_height_ - tile_img_height_, tile_img_width_, tile_img_height_, GL_BGR, GL_UNSIGNED_BYTE, ogl_pixel.data);
+
+    cv::flip(ogl_pixel, img, 0);
+
+    /* Swap the buffers. */
+    glfwSwapBuffers(window_);
+
+    pollOrPostEvent();
+
+    glBindFramebuffer(GL_FRAMEBUFFER, 0);
+
+    glfwMakeContextCurrent(nullptr);
+
+    return true;
+}
+
+
+bool SICAD::superimpose
+(
+    const ModelPoseContainer& objpos_map,
+    const double* cam_x,
+    const double* cam_o,
+    cv::Mat& img,
+    cv::Mat& depth
+)
+{
+    glfwMakeContextCurrent(window_);
+
+    glBindFramebuffer(GL_FRAMEBUFFER, fbo_);
+
+    /* Render in the upper-left-most tile of the render grid */
+    glViewport(0, framebuffer_height_ - tile_img_height_,
+               tile_img_width_, tile_img_height_);
+    glScissor(0, framebuffer_height_ - tile_img_height_,
+              tile_img_width_, tile_img_height_);
+
+    /* Clear the colorbuffer. */
+    glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
+    glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+
+    /* Draw the background picture. */
+    if (getBackgroundOpt())
+        renderBackground(img);
+
+    /* View mesh filled or as wireframe. */
+    setWireframe(getWireframeOpt());
+
+    /* View transformation matrix. */
+    glm::mat4 view = getViewTransformationMatrix(cam_x, cam_o);
+
+    /* Install/Use the program specified by the shader. */
+    shader_cad_->install();
+    glUniformMatrix4fv(glGetUniformLocation(shader_cad_->get_program(), "view"), 1, GL_FALSE, glm::value_ptr(view));
+    shader_cad_->uninstall();
+
+    shader_mesh_texture_->install();
+    glUniformMatrix4fv(glGetUniformLocation(shader_mesh_texture_->get_program(), "view"), 1, GL_FALSE, glm::value_ptr(view));
+    shader_mesh_texture_->uninstall();
+
+    shader_frame_->install();
+    glUniformMatrix4fv(glGetUniformLocation(shader_frame_->get_program(), "view"), 1, GL_FALSE, glm::value_ptr(view));
+    shader_frame_->uninstall();
+
+    /* Model transformation matrix. */
+    for (const ModelPoseContainerElement& pair : objpos_map)
+    {
+        const double* pose = pair.second.data();
+
+        glm::mat4 model = glm::rotate(glm::mat4(1.0f), static_cast<float>(pose[6]), glm::vec3(static_cast<float>(pose[3]), static_cast<float>(pose[4]), static_cast<float>(pose[5])));
+        model[3][0] = pose[0];
+        model[3][1] = pose[1];
+        model[3][2] = pose[2];
+
+        auto iter_model = model_obj_.find(pair.first);
+        if (iter_model != model_obj_.end())
+        {
+            if ((iter_model->second)->has_texture())
+            {
+                shader_mesh_texture_->install();
+                glUniformMatrix4fv(glGetUniformLocation(shader_mesh_texture_->get_program(), "model"), 1, GL_FALSE, glm::value_ptr(model));
+
+                (iter_model->second)->Draw(*shader_mesh_texture_);
+
+                shader_mesh_texture_->uninstall();
+            }
+            else
+            {
+                shader_cad_->install();
+                glUniformMatrix4fv(glGetUniformLocation(shader_cad_->get_program(), "model"), 1, GL_FALSE, glm::value_ptr(model));
+
+                (iter_model->second)->Draw(*shader_cad_);
+
+                shader_cad_->uninstall();
+            }
+        }
+        else if (pair.first == "frame")
+        {
+            shader_frame_->install();
+            glUniformMatrix4fv(glGetUniformLocation(shader_frame_->get_program(), "model"), 1, GL_FALSE, glm::value_ptr(model));
+            glBindVertexArray(vao_frame_);
+            glDrawArrays(GL_LINES, 0, 6);
+            glBindVertexArray(0);
+            shader_frame_->uninstall();
+        }
+    }
+
+    /* Read before swap. glReadPixels read the current framebuffer, i.e. the back one. */
+    /* See: http://stackoverflow.com/questions/16809833/opencv-image-loading-for-opengl-texture#16812529
+       and http://stackoverflow.com/questions/9097756/converting-data-from-glreadpixels-to-opencvmat#9098883 */
+    // cv::Mat ogl_pixel(framebuffer_height_ / tiles_rows_, framebuffer_width_ / tiles_cols_, CV_8UC3);
+    // glReadBuffer(GL_COLOR_ATTACHMENT0);
+    // glPixelStorei(GL_PACK_ALIGNMENT, (ogl_pixel.step & 3) ? 1 : 4);
+    // glPixelStorei(GL_PACK_ROW_LENGTH, ogl_pixel.step / ogl_pixel.elemSize());
+    // glReadPixels(0, framebuffer_height_ - tile_img_height_, tile_img_width_, tile_img_height_, GL_BGR, GL_UNSIGNED_BYTE, ogl_pixel.data);
+
+    // cv::flip(ogl_pixel, img, 0);
+
+
+    //cv::Mat ogl_depth(framebuffer_height_, framebuffer_width_, CV_32FC1);
+    //glReadBuffer(GL_DEPTH_ATTACHMENT);
+    //glReadPixels(0, 0, framebuffer_width_, framebuffer_height_, GL_DEPTH_COMPONENT, GL_FLOAT, ogl_depth.ptr<float>());
+
+    //cv::flip(ogl_depth, depth, 0);
+
+    ///* Math-reworked version of the fragment code of https://learnopengl.com/Advanced-OpenGL/Depth-testing, section "Visualizing the depth buffer". */
+    //const float iv1 = near_ * far_;
+    //const float iv2 = near_ - far_;
+    //depth.forEach<float>([&iv1, &iv2, this](float& p, const int* pos) -> void { p = iv1 / (far_ + p * iv2); });
+
+	cv::Mat ogl_depth(framebuffer_height_, framebuffer_width_, CV_32FC1);
+	glReadBuffer(GL_COLOR_ATTACHMENT1);
+	glReadPixels(0, 0, framebuffer_width_, framebuffer_height_, GL_RED, GL_FLOAT, ogl_depth.ptr<float>());
+
+	cv::flip(ogl_depth, depth, 0);
+
+
+    /* Swap the buffers. */
+    glfwSwapBuffers(window_);
+
+    pollOrPostEvent();
+
+    glBindFramebuffer(GL_FRAMEBUFFER, 0);
+
+    glfwMakeContextCurrent(nullptr);
+
+    return true;
+}
+
+
+bool SICAD::superimpose
+(
+    const std::vector<ModelPoseContainer>& objpos_multimap,
+    const double* cam_x,
+    const double* cam_o,
+    cv::Mat& img
+)
+{
+    /* Model transformation matrix. */
+    const int objpos_num = objpos_multimap.size();
+    if (objpos_num != tiles_num_) return false;
+
+    glfwMakeContextCurrent(window_);
+
+    glBindFramebuffer(GL_FRAMEBUFFER, fbo_);
+
+    /* View transformation matrix. */
+    glm::mat4 view = getViewTransformationMatrix(cam_x, cam_o);
+
+    /* Install/Use the program specified by the shader. */
+    shader_cad_->install();
+    glUniformMatrix4fv(glGetUniformLocation(shader_cad_->get_program(), "view"), 1, GL_FALSE, glm::value_ptr(view));
+    shader_cad_->uninstall();
+
+    shader_mesh_texture_->install();
+    glUniformMatrix4fv(glGetUniformLocation(shader_mesh_texture_->get_program(), "view"), 1, GL_FALSE, glm::value_ptr(view));
+    shader_mesh_texture_->uninstall();
+
+    shader_frame_->install();
+    glUniformMatrix4fv(glGetUniformLocation(shader_frame_->get_program(), "view"), 1, GL_FALSE, glm::value_ptr(view));
+    shader_frame_->uninstall();
+
+    for (unsigned int i = 0; i < tiles_rows_; ++i)
+    {
+        for (unsigned int j = 0; j < tiles_cols_; ++j)
+        {
+            /* Multimap index */
+            int idx = i * tiles_cols_ + j;
+
+            /* Render starting by the upper-left-most tile of the render grid, proceding by columns and rows. */
+            glViewport(tile_img_width_ * j, framebuffer_height_ - (tile_img_height_ * (i + 1)),
+                       tile_img_width_    , tile_img_height_                                   );
+            glScissor (tile_img_width_ * j, framebuffer_height_ - (tile_img_height_ * (i + 1)),
+                       tile_img_width_    , tile_img_height_                                   );
+
+            /* Clear the colorbuffer. */
+            glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
+            glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+
+            /* Draw the background picture. */
+            if (getBackgroundOpt())
+                renderBackground(img);
+
+            /* View mesh filled or as wireframe. */
+            setWireframe(getWireframeOpt());
+
+            /* Install/Use the program specified by the shader. */
+            for (const ModelPoseContainerElement& pair : objpos_multimap[idx])
+            {
+                const double* pose = pair.second.data();
+
+                glm::mat4 model = glm::rotate(glm::mat4(1.0f), static_cast<float>(pose[6]), glm::vec3(static_cast<float>(pose[3]), static_cast<float>(pose[4]), static_cast<float>(pose[5])));
+                model[3][0] = static_cast<float>(pose[0]);
+                model[3][1] = static_cast<float>(pose[1]);
+                model[3][2] = static_cast<float>(pose[2]);
+
+                auto iter_model = model_obj_.find(pair.first);
+                if (iter_model != model_obj_.end())
+                {
+                    if ((iter_model->second)->has_texture())
+                    {
+                        shader_mesh_texture_->install();
+                        glUniformMatrix4fv(glGetUniformLocation(shader_mesh_texture_->get_program(), "model"), 1, GL_FALSE, glm::value_ptr(model));
+
+                        (iter_model->second)->Draw(*shader_mesh_texture_);
+
+                        shader_mesh_texture_->uninstall();
+                    }
+                    else
+                    {
+                        shader_cad_->install();
+                        glUniformMatrix4fv(glGetUniformLocation(shader_cad_->get_program(), "model"), 1, GL_FALSE, glm::value_ptr(model));
+
+                        (iter_model->second)->Draw(*shader_cad_);
+
+                        shader_cad_->uninstall();
+                    }
+                }
+                else if (pair.first == "frame")
+                {
+                    shader_frame_->install();
+                    glUniformMatrix4fv(glGetUniformLocation(shader_frame_->get_program(), "model"), 1, GL_FALSE, glm::value_ptr(model));
+                    glBindVertexArray(vao_frame_);
+                    glDrawArrays(GL_LINES, 0, 6);
+                    glBindVertexArray(0);
+                    shader_frame_->uninstall();
+                }
+            }
+        }
+    }
+
+    /* Read before swap. glReadPixels read the current framebuffer, i.e. the back one. */
+    /* See: http://stackoverflow.com/questions/16809833/opencv-image-loading-for-opengl-texture#16812529
+       and http://stackoverflow.com/questions/9097756/converting-data-from-glreadpixels-to-opencvmat#9098883 */
+    cv::Mat ogl_pixel(framebuffer_height_, framebuffer_width_, CV_8UC3);
+    glReadBuffer(GL_COLOR_ATTACHMENT0);
+    glPixelStorei(GL_PACK_ALIGNMENT, (ogl_pixel.step & 3) ? 1 : 4);
+    glPixelStorei(GL_PACK_ROW_LENGTH, ogl_pixel.step/ogl_pixel.elemSize());
+    glReadPixels(0, 0, framebuffer_width_, framebuffer_height_, GL_BGR, GL_UNSIGNED_BYTE, ogl_pixel.data);
+
+    cv::flip(ogl_pixel, img, 0);
+
+
+    /* Swap the buffers. */
+    glfwSwapBuffers(window_);
+
+    pollOrPostEvent();
+
+    glBindFramebuffer(GL_FRAMEBUFFER, 0);
+
+    glfwMakeContextCurrent(nullptr);
+
+    return true;
+}
+
+
+bool SICAD::superimpose
+(
+    const std::vector<ModelPoseContainer>& objpos_multimap,
+    const double* cam_x,
+    const double* cam_o,
+    cv::Mat& img,
+    cv::Mat& depth
+)
+{
+    /* Model transformation matrix. */
+    const int objpos_num = objpos_multimap.size();
+    if (objpos_num != tiles_num_) return false;
+
+    glfwMakeContextCurrent(window_);
+
+    glBindFramebuffer(GL_FRAMEBUFFER, fbo_);
+
+    /* View transformation matrix. */
+    glm::mat4 view = getViewTransformationMatrix(cam_x, cam_o);
+
+    /* Install/Use the program specified by the shader. */
+    shader_cad_->install();
+    glUniformMatrix4fv(glGetUniformLocation(shader_cad_->get_program(), "view"), 1, GL_FALSE, glm::value_ptr(view));
+    shader_cad_->uninstall();
+
+    shader_mesh_texture_->install();
+    glUniformMatrix4fv(glGetUniformLocation(shader_mesh_texture_->get_program(), "view"), 1, GL_FALSE, glm::value_ptr(view));
+    shader_mesh_texture_->uninstall();
+
+    shader_frame_->install();
+    glUniformMatrix4fv(glGetUniformLocation(shader_frame_->get_program(), "view"), 1, GL_FALSE, glm::value_ptr(view));
+    shader_frame_->uninstall();
+
+    for (unsigned int i = 0; i < tiles_rows_; ++i)
+    {
+        for (unsigned int j = 0; j < tiles_cols_; ++j)
+        {
+            /* Multimap index */
+            int idx = i * tiles_cols_ + j;
+
+            /* Render starting by the upper-left-most tile of the render grid, proceding by columns and rows. */
+            glViewport(tile_img_width_ * j, framebuffer_height_ - (tile_img_height_ * (i + 1)),
+                       tile_img_width_, tile_img_height_);
+            glScissor(tile_img_width_ * j, framebuffer_height_ - (tile_img_height_ * (i + 1)),
+                      tile_img_width_, tile_img_height_);
+
+            /* Clear the colorbuffer. */
+            glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
+            glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+
+            /* Draw the background picture. */
+            if (getBackgroundOpt())
+                renderBackground(img);
+
+            /* View mesh filled or as wireframe. */
+            setWireframe(getWireframeOpt());
+
+            /* Install/Use the program specified by the shader. */
+            for (const ModelPoseContainerElement& pair : objpos_multimap[idx])
+            {
+                const double* pose = pair.second.data();
+
+                glm::mat4 model = glm::rotate(glm::mat4(1.0f), static_cast<float>(pose[6]), glm::vec3(static_cast<float>(pose[3]), static_cast<float>(pose[4]), static_cast<float>(pose[5])));
+                model[3][0] = static_cast<float>(pose[0]);
+                model[3][1] = static_cast<float>(pose[1]);
+                model[3][2] = static_cast<float>(pose[2]);
+
+                auto iter_model = model_obj_.find(pair.first);
+                if (iter_model != model_obj_.end())
+                {
+                    if ((iter_model->second)->has_texture())
+                    {
+                        shader_mesh_texture_->install();
+                        glUniformMatrix4fv(glGetUniformLocation(shader_mesh_texture_->get_program(), "model"), 1, GL_FALSE, glm::value_ptr(model));
+
+                        (iter_model->second)->Draw(*shader_mesh_texture_);
+
+                        shader_mesh_texture_->uninstall();
+                    }
+                    else
+                    {
+                        shader_cad_->install();
+                        glUniformMatrix4fv(glGetUniformLocation(shader_cad_->get_program(), "model"), 1, GL_FALSE, glm::value_ptr(model));
+
+                        (iter_model->second)->Draw(*shader_cad_);
+
+                        shader_cad_->uninstall();
+                    }
+                }
+                else if (pair.first == "frame")
+                {
+                    shader_frame_->install();
+                    glUniformMatrix4fv(glGetUniformLocation(shader_frame_->get_program(), "model"), 1, GL_FALSE, glm::value_ptr(model));
+                    glBindVertexArray(vao_frame_);
+                    glDrawArrays(GL_LINES, 0, 6);
+                    glBindVertexArray(0);
+                    shader_frame_->uninstall();
+                }
+            }
+        }
+    }
+
+    /* Read before swap. glReadPixels read the current framebuffer, i.e. the back one. */
+    /* See: http://stackoverflow.com/questions/16809833/opencv-image-loading-for-opengl-texture#16812529
+    and http://stackoverflow.com/questions/9097756/converting-data-from-glreadpixels-to-opencvmat#9098883 */
+    // cv::Mat ogl_pixel(framebuffer_height_, framebuffer_width_, CV_8UC3);
+    // glReadBuffer(GL_COLOR_ATTACHMENT0);
+    // glPixelStorei(GL_PACK_ALIGNMENT, (ogl_pixel.step & 3) ? 1 : 4);
+    // glPixelStorei(GL_PACK_ROW_LENGTH, ogl_pixel.step / ogl_pixel.elemSize());
+    // glReadPixels(0, 0, framebuffer_width_, framebuffer_height_, GL_BGR, GL_UNSIGNED_BYTE, ogl_pixel.data);
+
+    // cv::flip(ogl_pixel, img, 0);
+
+
+    //cv::Mat ogl_depth(framebuffer_height_, framebuffer_width_, CV_32FC1);
+    //glReadBuffer(GL_DEPTH_ATTACHMENT);
+    //glReadPixels(0, 0, framebuffer_width_, framebuffer_height_, GL_DEPTH_COMPONENT, GL_FLOAT, ogl_depth.ptr<float>());
+
+    //cv::flip(ogl_depth, depth, 0);
+
+    //const float iv1 = near_ * far_;
+    //const float iv2 = near_ - far_;
+    //depth.forEach<float>([&iv1, &iv2, this](float& p, const int* pos) -> void { p = iv1 / (far_ + p * iv2); });
+
+	cv::Mat ogl_depth(framebuffer_height_, framebuffer_width_, CV_32FC1);
+	glReadBuffer(GL_COLOR_ATTACHMENT1);
+	glReadPixels(0, 0, framebuffer_width_, framebuffer_height_, GL_RED, GL_FLOAT, ogl_depth.ptr<float>());
+
+	cv::flip(ogl_depth, depth, 0);
+
+
+    /* Swap the buffers. */
+    glfwSwapBuffers(window_);
+
+    pollOrPostEvent();
+
+    glBindFramebuffer(GL_FRAMEBUFFER, 0);
+
+    glfwMakeContextCurrent(nullptr);
+
+    return true;
+}
+
+
+bool SICAD::superimpose
+(
+    const ModelPoseContainer& objpos_map,
+    const double* cam_x,
+    const double* cam_o,
+    cv::Mat& img,
+    const GLsizei cam_width,
+    const GLsizei cam_height,
+    const GLfloat cam_fx,
+    const GLfloat cam_fy,
+    const GLfloat cam_cx,
+    const GLfloat cam_cy
+)
+{
+    if (!setProjectionMatrix(cam_width, cam_height, cam_fx, cam_fy, cam_cx, cam_cy))
+        return false;
+
+    return superimpose(objpos_map, cam_x, cam_o, img);
+}
+
+
+bool SICAD::superimpose
+(
+    const std::vector<ModelPoseContainer>& objpos_multimap,
+    const double* cam_x,
+    const double* cam_o,
+    cv::Mat& img,
+    const GLsizei cam_width,
+    const GLsizei cam_height,
+    const GLfloat cam_fx,
+    const GLfloat cam_fy,
+    const GLfloat cam_cx,
+    const GLfloat cam_cy
+)
+{
+    if (!setProjectionMatrix(cam_width, cam_height, cam_fx, cam_fy, cam_cx, cam_cy))
+        return false;
+
+    return superimpose(objpos_multimap, cam_x, cam_o, img);
+}
+
+
+bool SICAD::superimpose
+(
+    const ModelPoseContainer& objpos_map,
+    const double* cam_x,
+    const double* cam_o,
+    const size_t pbo_index
+)
+{
+    if (!(pbo_index < pbo_number_))
+    {
+        std::cerr << "ERROR::SICAD::SUPERIMPOSE\nERROR:\n\tSICAD PBO index out of bound." << std::endl;
+        return false;
+    }
+
+
+    glfwMakeContextCurrent(window_);
+
+    glBindFramebuffer(GL_FRAMEBUFFER, fbo_);
+
+    /* Render in the upper-left-most tile of the render grid */
+    glViewport(0,               framebuffer_height_ - tile_img_height_,
+               tile_img_width_, tile_img_height_                       );
+    glScissor (0,               framebuffer_height_ - tile_img_height_,
+               tile_img_width_, tile_img_height_                       );
+
+    /* Clear the colorbuffer. */
+    glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
+    glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+
+    /* View mesh filled or as wireframe. */
+    setWireframe(getWireframeOpt());
+
+    /* View transformation matrix. */
+    glm::mat4 view = getViewTransformationMatrix(cam_x, cam_o);
+
+    /* Install/Use the program specified by the shader. */
+    shader_cad_->install();
+    glUniformMatrix4fv(glGetUniformLocation(shader_cad_->get_program(), "view"), 1, GL_FALSE, glm::value_ptr(view));
+    shader_cad_->uninstall();
+
+    shader_mesh_texture_->install();
+    glUniformMatrix4fv(glGetUniformLocation(shader_mesh_texture_->get_program(), "view"), 1, GL_FALSE, glm::value_ptr(view));
+    shader_mesh_texture_->uninstall();
+
+    shader_frame_->install();
+    glUniformMatrix4fv(glGetUniformLocation(shader_frame_->get_program(), "view"), 1, GL_FALSE, glm::value_ptr(view));
+    shader_frame_->uninstall();
+
+    /* Model transformation matrix. */
+    for (const ModelPoseContainerElement& pair : objpos_map)
+    {
+        const double* pose = pair.second.data();
+
+        glm::mat4 model = glm::rotate(glm::mat4(1.0f), static_cast<float>(pose[6]), glm::vec3(static_cast<float>(pose[3]), static_cast<float>(pose[4]), static_cast<float>(pose[5])));
+        model[3][0] = pose[0];
+        model[3][1] = pose[1];
+        model[3][2] = pose[2];
+
+        auto iter_model = model_obj_.find(pair.first);
+        if (iter_model != model_obj_.end())
+        {
+            if ((iter_model->second)->has_texture())
+            {
+                shader_mesh_texture_->install();
+                glUniformMatrix4fv(glGetUniformLocation(shader_mesh_texture_->get_program(), "model"), 1, GL_FALSE, glm::value_ptr(model));
+
+                (iter_model->second)->Draw(*shader_mesh_texture_);
+
+                shader_mesh_texture_->uninstall();
+            }
+            else
+            {
+                shader_cad_->install();
+                glUniformMatrix4fv(glGetUniformLocation(shader_cad_->get_program(), "model"), 1, GL_FALSE, glm::value_ptr(model));
+
+                (iter_model->second)->Draw(*shader_cad_);
+
+                shader_cad_->uninstall();
+            }
+        }
+        else if (pair.first == "frame")
+        {
+            shader_frame_->install();
+            glUniformMatrix4fv(glGetUniformLocation(shader_frame_->get_program(), "model"), 1, GL_FALSE, glm::value_ptr(model));
+            glBindVertexArray(vao_frame_);
+            glDrawArrays(GL_LINES, 0, 6);
+            glBindVertexArray(0);
+            shader_frame_->uninstall();
+        }
+    }
+
+    glReadBuffer(GL_COLOR_ATTACHMENT0);
+    glBindBuffer(GL_PIXEL_PACK_BUFFER, pbo_[pbo_index]);
+    glReadPixels(0, framebuffer_height_ - tile_img_height_, tile_img_width_, tile_img_height_, GL_BGR, GL_UNSIGNED_BYTE, 0);
+
+    /* Swap the buffers. */
+    glfwSwapBuffers(window_);
+
+    pollOrPostEvent();
+
+    glBindBuffer(GL_PIXEL_PACK_BUFFER, 0);
+    glBindFramebuffer(GL_FRAMEBUFFER, 0);
+
+    return true;
+}
+
+
+bool SICAD::superimpose
+(
+    const ModelPoseContainer& objpos_map,
+    const double* cam_x,
+    const double* cam_o,
+    const size_t pbo_index,
+    const cv::Mat& img
+)
+{
+    if (!(pbo_index < pbo_number_))
+    {
+        std::cerr << "ERROR::SICAD::SUPERIMPOSE\nERROR:\n\tSICAD PBO index out of bound." << std::endl;
+        return false;
+    }
+
+
+    glfwMakeContextCurrent(window_);
+
+    glBindFramebuffer(GL_FRAMEBUFFER, fbo_);
+
+    /* Render in the upper-left-most tile of the render grid */
+    glViewport(0,               framebuffer_height_ - tile_img_height_,
+               tile_img_width_, tile_img_height_                       );
+    glScissor (0,               framebuffer_height_ - tile_img_height_,
+               tile_img_width_, tile_img_height_                       );
+
+    /* Clear the colorbuffer. */
+    glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
+    glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+
+    /* Draw the background picture. */
+    if (getBackgroundOpt())
+        renderBackground(img);
+
+    /* View mesh filled or as wireframe. */
+    setWireframe(getWireframeOpt());
+
+    /* View transformation matrix. */
+    glm::mat4 view = getViewTransformationMatrix(cam_x, cam_o);
+
+    /* Install/Use the program specified by the shader. */
+    shader_cad_->install();
+    glUniformMatrix4fv(glGetUniformLocation(shader_cad_->get_program(), "view"), 1, GL_FALSE, glm::value_ptr(view));
+    shader_cad_->uninstall();
+
+    shader_mesh_texture_->install();
+    glUniformMatrix4fv(glGetUniformLocation(shader_mesh_texture_->get_program(), "view"), 1, GL_FALSE, glm::value_ptr(view));
+    shader_mesh_texture_->uninstall();
+
+    shader_frame_->install();
+    glUniformMatrix4fv(glGetUniformLocation(shader_frame_->get_program(), "view"), 1, GL_FALSE, glm::value_ptr(view));
+    shader_frame_->uninstall();
+
+    /* Model transformation matrix. */
+    for (const ModelPoseContainerElement& pair : objpos_map)
+    {
+        const double* pose = pair.second.data();
+
+        glm::mat4 model = glm::rotate(glm::mat4(1.0f), static_cast<float>(pose[6]), glm::vec3(static_cast<float>(pose[3]), static_cast<float>(pose[4]), static_cast<float>(pose[5])));
+        model[3][0] = pose[0];
+        model[3][1] = pose[1];
+        model[3][2] = pose[2];
+
+        auto iter_model = model_obj_.find(pair.first);
+        if (iter_model != model_obj_.end())
+        {
+            if ((iter_model->second)->has_texture())
+            {
+                shader_mesh_texture_->install();
+                glUniformMatrix4fv(glGetUniformLocation(shader_mesh_texture_->get_program(), "model"), 1, GL_FALSE, glm::value_ptr(model));
+
+                (iter_model->second)->Draw(*shader_mesh_texture_);
+
+                shader_mesh_texture_->uninstall();
+            }
+            else
+            {
+                shader_cad_->install();
+                glUniformMatrix4fv(glGetUniformLocation(shader_cad_->get_program(), "model"), 1, GL_FALSE, glm::value_ptr(model));
+
+                (iter_model->second)->Draw(*shader_cad_);
+
+                shader_cad_->uninstall();
+            }
+        }
+        else if (pair.first == "frame")
+        {
+            shader_frame_->install();
+            glUniformMatrix4fv(glGetUniformLocation(shader_frame_->get_program(), "model"), 1, GL_FALSE, glm::value_ptr(model));
+            glBindVertexArray(vao_frame_);
+            glDrawArrays(GL_LINES, 0, 6);
+            glBindVertexArray(0);
+            shader_frame_->uninstall();
+        }
+    }
+
+    glReadBuffer(GL_COLOR_ATTACHMENT0);
+    glBindBuffer(GL_PIXEL_PACK_BUFFER, pbo_[pbo_index]);
+    glReadPixels(0, framebuffer_height_ - tile_img_height_, tile_img_width_, tile_img_height_, GL_BGR, GL_UNSIGNED_BYTE, 0);
+
+    /* Swap the buffers. */
+    glfwSwapBuffers(window_);
+
+    pollOrPostEvent();
+
+    glBindBuffer(GL_PIXEL_PACK_BUFFER, 0);
+    glBindFramebuffer(GL_FRAMEBUFFER, 0);
+
+    return true;
+}
+
+
+bool SICAD::superimpose
+(
+    const std::vector<ModelPoseContainer>& objpos_multimap,
+    const double* cam_x,
+    const double* cam_o,
+    const size_t pbo_index
+)
+{
+    if (!(pbo_index < pbo_number_))
+    {
+        std::cerr << "ERROR::SICAD::SUPERIMPOSE\nERROR:\n\tSICAD PBO index out of bound." << std::endl;
+        return false;
+    }
+
+
+    /* Model transformation matrix. */
+    const int objpos_num = objpos_multimap.size();
+    if (objpos_num != tiles_num_) return false;
+
+    glfwMakeContextCurrent(window_);
+
+    glBindFramebuffer(GL_FRAMEBUFFER, fbo_);
+
+    /* View transformation matrix. */
+    glm::mat4 view = getViewTransformationMatrix(cam_x, cam_o);
+
+    /* Install/Use the program specified by the shader. */
+    shader_cad_->install();
+    glUniformMatrix4fv(glGetUniformLocation(shader_cad_->get_program(), "view"), 1, GL_FALSE, glm::value_ptr(view));
+    shader_cad_->uninstall();
+
+    shader_mesh_texture_->install();
+    glUniformMatrix4fv(glGetUniformLocation(shader_mesh_texture_->get_program(), "view"), 1, GL_FALSE, glm::value_ptr(view));
+    shader_mesh_texture_->uninstall();
+
+    shader_frame_->install();
+    glUniformMatrix4fv(glGetUniformLocation(shader_frame_->get_program(), "view"), 1, GL_FALSE, glm::value_ptr(view));
+    shader_frame_->uninstall();
+
+    for (unsigned int i = 0; i < tiles_rows_; ++i)
+    {
+        for (unsigned int j = 0; j < tiles_cols_; ++j)
+        {
+            /* Multimap index */
+            int idx = i * tiles_cols_ + j;
+
+            /* Render starting by the upper-left-most tile of the render grid, proceding by columns and rows. */
+            glViewport(tile_img_width_ * j, framebuffer_height_ - (tile_img_height_ * (i + 1)),
+                       tile_img_width_,     tile_img_height_                                   );
+            glScissor (tile_img_width_ * j, framebuffer_height_ - (tile_img_height_ * (i + 1)),
+                       tile_img_width_,     tile_img_height_                                   );
+
+            /* Clear the colorbuffer. */
+            glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
+            glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+
+            /* View mesh filled or as wireframe. */
+            setWireframe(getWireframeOpt());
+
+            /* Install/Use the program specified by the shader. */
+            for (const ModelPoseContainerElement& pair : objpos_multimap[idx])
+            {
+                const double* pose = pair.second.data();
+
+                glm::mat4 model = glm::rotate(glm::mat4(1.0f), static_cast<float>(pose[6]), glm::vec3(static_cast<float>(pose[3]), static_cast<float>(pose[4]), static_cast<float>(pose[5])));
+                model[3][0] = static_cast<float>(pose[0]);
+                model[3][1] = static_cast<float>(pose[1]);
+                model[3][2] = static_cast<float>(pose[2]);
+
+                auto iter_model = model_obj_.find(pair.first);
+                if (iter_model != model_obj_.end())
+                {
+                    if ((iter_model->second)->has_texture())
+                    {
+                        shader_mesh_texture_->install();
+                        glUniformMatrix4fv(glGetUniformLocation(shader_mesh_texture_->get_program(), "model"), 1, GL_FALSE, glm::value_ptr(model));
+
+                        (iter_model->second)->Draw(*shader_mesh_texture_);
+
+                        shader_mesh_texture_->uninstall();
+                    }
+                    else
+                    {
+                        shader_cad_->install();
+                        glUniformMatrix4fv(glGetUniformLocation(shader_cad_->get_program(), "model"), 1, GL_FALSE, glm::value_ptr(model));
+
+                        (iter_model->second)->Draw(*shader_cad_);
+
+                        shader_cad_->uninstall();
+                    }
+                }
+                else if (pair.first == "frame")
+                {
+                    shader_frame_->install();
+                    glUniformMatrix4fv(glGetUniformLocation(shader_frame_->get_program(), "model"), 1, GL_FALSE, glm::value_ptr(model));
+                    glBindVertexArray(vao_frame_);
+                    glDrawArrays(GL_LINES, 0, 6);
+                    glBindVertexArray(0);
+                    shader_frame_->uninstall();
+                }
+            }
+        }
+    }
+
+    glReadBuffer(GL_COLOR_ATTACHMENT0);
+    glBindBuffer(GL_PIXEL_PACK_BUFFER, pbo_[pbo_index]);
+    glReadPixels(0, 0, framebuffer_width_, framebuffer_height_, GL_BGR, GL_UNSIGNED_BYTE, 0);
+
+    /* Swap the buffers. */
+    glfwSwapBuffers(window_);
+
+    pollOrPostEvent();
+
+    glBindBuffer(GL_PIXEL_PACK_BUFFER, 0);
+    glBindFramebuffer(GL_FRAMEBUFFER, 0);
+
+    return true;
+}
+
+
+bool SICAD::superimpose
+(
+    const std::vector<ModelPoseContainer>& objpos_multimap,
+    const double* cam_x,
+    const double* cam_o,
+    const size_t pbo_index,
+    const cv::Mat& img
+)
+{
+    if (!(pbo_index < pbo_number_))
+    {
+        std::cerr << "ERROR::SICAD::SUPERIMPOSE\nERROR:\n\tSICAD PBO index out of bound." << std::endl;
+        return false;
+    }
+
+
+    /* Model transformation matrix. */
+    const int objpos_num = objpos_multimap.size();
+    if (objpos_num != tiles_num_) return false;
+
+    glfwMakeContextCurrent(window_);
+
+    glBindFramebuffer(GL_FRAMEBUFFER, fbo_);
+
+    /* View transformation matrix. */
+    glm::mat4 view = getViewTransformationMatrix(cam_x, cam_o);
+
+    /* Install/Use the program specified by the shader. */
+    shader_cad_->install();
+    glUniformMatrix4fv(glGetUniformLocation(shader_cad_->get_program(), "view"), 1, GL_FALSE, glm::value_ptr(view));
+    shader_cad_->uninstall();
+
+    shader_mesh_texture_->install();
+    glUniformMatrix4fv(glGetUniformLocation(shader_mesh_texture_->get_program(), "view"), 1, GL_FALSE, glm::value_ptr(view));
+    shader_mesh_texture_->uninstall();
+
+    shader_frame_->install();
+    glUniformMatrix4fv(glGetUniformLocation(shader_frame_->get_program(), "view"), 1, GL_FALSE, glm::value_ptr(view));
+    shader_frame_->uninstall();
+
+    for (unsigned int i = 0; i < tiles_rows_; ++i)
+    {
+        for (unsigned int j = 0; j < tiles_cols_; ++j)
+        {
+            /* Multimap index */
+            int idx = i * tiles_cols_ + j;
+
+            /* Render starting by the upper-left-most tile of the render grid, proceding by columns and rows. */
+            glViewport(tile_img_width_ * j, framebuffer_height_ - (tile_img_height_ * (i + 1)),
+                       tile_img_width_,     tile_img_height_                                   );
+            glScissor (tile_img_width_ * j, framebuffer_height_ - (tile_img_height_ * (i + 1)),
+                       tile_img_width_,     tile_img_height_                                   );
+
+            /* Clear the colorbuffer. */
+            glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
+            glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+
+            /* Draw the background picture. */
+            if (getBackgroundOpt())
+                renderBackground(img);
+
+            /* View mesh filled or as wireframe. */
+            setWireframe(getWireframeOpt());
+
+            /* Install/Use the program specified by the shader. */
+            for (const ModelPoseContainerElement& pair : objpos_multimap[idx])
+            {
+                const double* pose = pair.second.data();
+
+                glm::mat4 model = glm::rotate(glm::mat4(1.0f), static_cast<float>(pose[6]), glm::vec3(static_cast<float>(pose[3]), static_cast<float>(pose[4]), static_cast<float>(pose[5])));
+                model[3][0] = static_cast<float>(pose[0]);
+                model[3][1] = static_cast<float>(pose[1]);
+                model[3][2] = static_cast<float>(pose[2]);
+
+                auto iter_model = model_obj_.find(pair.first);
+                if (iter_model != model_obj_.end())
+                {
+                    if ((iter_model->second)->has_texture())
+                    {
+                        shader_mesh_texture_->install();
+                        glUniformMatrix4fv(glGetUniformLocation(shader_mesh_texture_->get_program(), "model"), 1, GL_FALSE, glm::value_ptr(model));
+
+                        (iter_model->second)->Draw(*shader_mesh_texture_);
+
+                        shader_mesh_texture_->uninstall();
+                    }
+                    else
+                    {
+                        shader_cad_->install();
+                        glUniformMatrix4fv(glGetUniformLocation(shader_cad_->get_program(), "model"), 1, GL_FALSE, glm::value_ptr(model));
+
+                        (iter_model->second)->Draw(*shader_cad_);
+
+                        shader_cad_->uninstall();
+                    }
+                }
+                else if (pair.first == "frame")
+                {
+                    shader_frame_->install();
+                    glUniformMatrix4fv(glGetUniformLocation(shader_frame_->get_program(), "model"), 1, GL_FALSE, glm::value_ptr(model));
+                    glBindVertexArray(vao_frame_);
+                    glDrawArrays(GL_LINES, 0, 6);
+                    glBindVertexArray(0);
+                    shader_frame_->uninstall();
+                }
+            }
+        }
+    }
+
+    glReadBuffer(GL_COLOR_ATTACHMENT0);
+    glBindBuffer(GL_PIXEL_PACK_BUFFER, pbo_[pbo_index]);
+    glReadPixels(0, 0, framebuffer_width_, framebuffer_height_, GL_BGR, GL_UNSIGNED_BYTE, 0);
+
+    /* Swap the buffers. */
+    glfwSwapBuffers(window_);
+
+    pollOrPostEvent();
+
+    glBindBuffer(GL_PIXEL_PACK_BUFFER, 0);
+    glBindFramebuffer(GL_FRAMEBUFFER, 0);
+
+    return true;
+}
+
+
+void SICAD::releaseContext() const
+{
+    glfwMakeContextCurrent(nullptr);
+}
+
+
+std::pair<const GLuint*, size_t> SICAD::getPBOs() const
+{
+    glfwMakeContextCurrent(window_);
+
+    return std::make_pair(pbo_, pbo_number_);
+}
+
+
+std::pair<bool, GLuint> SICAD::getPBO(const size_t pbo_index) const
+{
+    if (pbo_index < pbo_number_)
+    {
+        glfwMakeContextCurrent(window_);
+
+        return std::make_pair(true, pbo_[pbo_index]);
+    }
+
+    return std::make_pair(false, 0);
+}
+
+
+bool SICAD::setProjectionMatrix
+(
+    const GLsizei cam_width,
+    const GLsizei cam_height,
+    const GLfloat cam_fx,
+    const GLfloat cam_fy,
+    const GLfloat cam_cx,
+    const GLfloat cam_cy
+)
+{
+    glfwMakeContextCurrent(window_);
+
+    /* Projection matrix. */
+    /* In both OpenGL window coordinates and Hartley-Zisserman (HZ) image coordinate systems, (0,0) is the lower left corner with X and Y increasing right and up, respectively. In a normal image file, the (0,0) pixel is in the upper left corner.
+       There are two possibilities to convert this coordinate system into the image file system coordinate (also used by OpenCV).
+       1. We can render/draw our images upside down, so that we have already a correspondence between OpenGL and image coordinate systems.
+          The projection matrix is the following:
+          [2*K00/width,  -2*K01/width,   (width - 2*K02 + 2*x0)/width,                            0]
+          [          0, -2*K11/height, (height - 2*K12 + 2*y0)/height,                            0]
+          [          0,             0, (-zfar - znear)/(zfar - znear), -2*zfar*znear/(zfar - znear)]
+          [          0,             0,                             -1,                            0]
+       2. We can render/draw our image normally and compensate the the flipped image externally (e.g. with OpenCV flip()).
+          The projection matrix is the following:
+          [2*K00/width, -2*K01/width,    (width - 2*K02 + 2*x0)/width,                            0]
+          [          0, 2*K11/height, (-height + 2*K12 + 2*y0)/height,                            0]
+          [          0,            0,  (-zfar - znear)/(zfar - znear), -2*zfar*znear/(zfar - znear)]
+          [          0,            0,                              -1,                            0]
+       Where "Knm" is the (n,m) entry of the 3x3 HZ instrinsic camera calibration matrix K. K is upper triangular and scaled such that the lower-right entry is one. "width" and "height" are the size of the camera image, in pixels, and "x0" and "y0" are the camera image origin, which are normally zero. "znear" and "zfar" are the standard OpenGL near and far clipping planes, respectively. */
+    // projection_ = glm::mat4(2.0f*(cam_fx/cam_width),    0,                              0,                                  0,
+    //                         0,                          -2.0f*(cam_fy/cam_height),      0,                                  0,
+    //                         1-2.0f*(cam_cx/cam_width),  1-2.0f*(cam_cy/cam_height),    -(far_+near_)/(far_-near_),         -1,
+    //                         0,                          0,                             -2.0f*(far_*near_)/(far_-near_),     0);
+
+    projection_ = glm::mat4(2.0f*(cam_fx/cam_width),    0,                           0,                               0,
+                            0,                          2.0f*(cam_fy/cam_height),    0,                               0,
+                            1-2.0f*(cam_cx/cam_width),  2.0f*(cam_cy/cam_height)-1, -(far_+near_)/(far_-near_),      -1,
+                            0,                          0,                          -2.0f*(far_*near_)/(far_-near_),  0 );
+
+    /* Install/Use the program specified by the shader. */
+    shader_cad_->install();
+    glUniformMatrix4fv(glGetUniformLocation(shader_cad_->get_program(), "projection"), 1, GL_FALSE, glm::value_ptr(projection_));
+    shader_cad_->uninstall();
+
+    shader_mesh_texture_->install();
+    glUniformMatrix4fv(glGetUniformLocation(shader_mesh_texture_->get_program(), "projection"), 1, GL_FALSE, glm::value_ptr(projection_));
+    shader_mesh_texture_->uninstall();
+
+    shader_frame_->install();
+    glUniformMatrix4fv(glGetUniformLocation(shader_frame_->get_program(), "projection"), 1, GL_FALSE, glm::value_ptr(projection_));
+    shader_frame_->uninstall();
+
+    glfwSwapBuffers(window_);
+    glfwMakeContextCurrent(nullptr);
+
+    return true;
+}
+
+
+void SICAD::setOglToCam(const std::vector<float>& ogl_to_cam)
+{
+    if (ogl_to_cam.size() != 4)
+        throw std::runtime_error("ERROR::SICAD::setOglToCam\nERROR:\n\tWrong input size.\n\tShould be 4, was given " + std::to_string(ogl_to_cam.size()) + ".");
+
+    ogl_to_cam_ = glm::mat3(glm::rotate(glm::mat4(1.0f), ogl_to_cam[3], glm::make_vec3(ogl_to_cam.data())));
+}
+
+
+void SICAD::setBackgroundOpt(bool show_background)
+{
+    show_background_ = show_background;
+}
+
+
+bool SICAD::getBackgroundOpt() const
+{
+    return show_background_;
+}
+
+
+void SICAD::setWireframeOpt(bool show_mesh_wires)
+{
+    if  (show_mesh_wires) show_mesh_mode_ = GL_LINE;
+    else                  show_mesh_mode_ = GL_FILL;
+}
+
+
+void SICAD::setMipmapsOpt(const MIPMaps& mipmaps)
+{
+    mesh_mmaps_ = mipmaps;
+}
+
+
+GLenum SICAD::getWireframeOpt() const
+{
+    return show_mesh_mode_;
+}
+
+
+SICAD::MIPMaps SICAD::getMipmapsOpt() const
+{
+    return mesh_mmaps_;
+}
+
+
+int SICAD::getTilesNumber() const
+{
+    return tiles_rows_ * tiles_cols_;
+}
+
+
+int SICAD::getTilesRows() const
+{
+    return tiles_rows_;
+}
+
+
+int SICAD::getTilesCols() const
+{
+    return tiles_cols_;
+}
+
+
+glm::mat4 SICAD::getViewTransformationMatrix(const double* cam_x, const double* cam_o)
+{
+    glm::mat4 root_cam_t  = glm::translate(glm::mat4(1.0f),
+                                           glm::vec3(static_cast<float>(cam_x[0]), static_cast<float>(cam_x[1]), static_cast<float>(cam_x[2])));
+    glm::mat4 cam_to_root = glm::rotate(glm::mat4(1.0f),
+                                        static_cast<float>(cam_o[3]), glm::vec3(static_cast<float>(cam_o[0]), static_cast<float>(cam_o[1]), static_cast<float>(cam_o[2])));
+
+    glm::mat4 view = glm::lookAt(glm::vec3(root_cam_t[3].x, root_cam_t[3].y, root_cam_t[3].z),
+                                 glm::vec3(root_cam_t[3].x, root_cam_t[3].y, root_cam_t[3].z) + glm::mat3(cam_to_root) * ogl_to_cam_ * glm::vec3(0.0f, 0.0f, -1.0f),
+                                 glm::mat3(cam_to_root) * ogl_to_cam_ * glm::vec3(0.0f, 1.0f, 0.0f));
+
+    return view;
+}
+
+
+void SICAD::pollOrPostEvent()
+{
+    if(main_thread_id_ == std::this_thread::get_id())
+        glfwPollEvents();
+    else
+        glfwPostEmptyEvent();
+}
+
+
+void SICAD::renderBackground(const cv::Mat& img) const
+{
+    /* Load and generate the texture. */
+    glBindTexture(GL_TEXTURE_2D, texture_background_);
+
+    /* Set the texture wrapping/filtering options (on the currently bound texture object). */
+    if (getMipmapsOpt() == MIPMaps::nearest)
+    {
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST_MIPMAP_NEAREST);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+    }
+    else if (getMipmapsOpt() == MIPMaps::linear)
+    {
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR_MIPMAP_LINEAR);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+    }
+
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, img.cols, img.rows, 0, GL_BGR, GL_UNSIGNED_BYTE, img.data);
+    glGenerateMipmap(GL_TEXTURE_2D);
+
+    glPolygonMode(GL_FRONT_AND_BACK, GL_FILL);
+
+    /* Install/Use the program specified by the shader. */
+    shader_background_->install();
+    glUniformMatrix4fv(glGetUniformLocation(shader_background_->get_program(), "projection"), 1, GL_FALSE, glm::value_ptr(back_proj_));
+
+    glBindVertexArray(vao_background_);
+    glDrawElements(GL_TRIANGLES, 6, GL_UNSIGNED_INT, 0);
+    glBindVertexArray(0);
+
+    glBindTexture(GL_TEXTURE_2D, 0);
+    shader_background_->uninstall();
+}
+
+
+void SICAD::setWireframe(GLenum mode)
+{
+    glPolygonMode(GL_FRONT_AND_BACK, mode);
+}
+
+
+void SICAD::factorize_int
+(
+    const GLsizei area,
+    const GLsizei width_limit,
+    const GLsizei height_limit,
+    GLsizei& width,
+    GLsizei& height
+)
+{
+    double sqrt_area = std::floor(std::sqrt(static_cast<double>(area)));
+    height = std::min(static_cast<int>(sqrt_area), height_limit);
+    width  = std::min(area / height,               width_limit);
+}

--- a/src/roft-lib/src/SICADModel.cpp
+++ b/src/roft-lib/src/SICADModel.cpp
@@ -1,0 +1,244 @@
+/*
+ * Copyright (C) 2022 Istituto Italiano di Tecnologia (IIT)
+ *
+ * This software may be modified and distributed under the terms of the
+ * GPL-2+ license. See the accompanying LICENSE file for details.
+ *
+ *
+ * Part of this code is taken from https://github.com/robotology/superimpose-mesh-lib/commits/impl/depth
+ *
+ * This is the original BSD 3-Clause LICENSE the original code was provided with:
+ *
+ * Copyright (c) 2016-2019, Istituto Italiano di Tecnologia (IIT) All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+ * - Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ * - Neither the name of the organization nor the names of its contributors may be used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL CLAUDIO FANTACCI BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <SuperimposeMesh/Shader.h>
+
+#include <ROFT/SICADModel.h>
+
+#include <sstream>
+#include <iostream>
+
+#include <assimp/Importer.hpp>
+#include <assimp/postprocess.h>
+
+#include <glm/glm.hpp>
+
+#include <opencv2/core/core.hpp>
+#include <opencv2/highgui/highgui.hpp>
+
+using namespace ROFT;
+
+
+SICADModel::SICADModel(const GLchar* path)
+{
+    loadModel(path);
+}
+
+
+SICADModel::SICADModel(const std::basic_istream<char>* model_stream)
+{
+    loadModel(model_stream);
+}
+
+
+void SICADModel::Draw(SICADShader shader)
+{
+    Shader* shader_ptr = (Shader*)&shader;
+    for(GLuint i = 0; i < meshes_.size(); i++)
+    {
+        meshes_[i].Draw(*shader_ptr);
+    }
+}
+
+
+bool SICADModel::has_texture()
+{
+    return (textures_loaded_.size() > 0 ? true : false);
+}
+
+
+void SICADModel::loadModel(std::string path)
+{
+    Assimp::Importer import;
+    const aiScene* scene = import.ReadFile(path, aiProcess_Triangulate | aiProcess_FlipUVs);
+
+    if(!scene || scene->mFlags == AI_SCENE_FLAGS_INCOMPLETE || !scene->mRootNode)
+    {
+        std::cerr << "ERROR::ASSIMP::" << import.GetErrorString() << std::endl;
+        return;
+    }
+
+    size_t foundpos = path.find_last_of('/');
+    if (foundpos == std::string::npos)
+    {
+       directory_ = ".";
+    }
+    else
+    {
+       directory_ = path.substr(0, foundpos);
+    }
+
+    processNode(scene->mRootNode, scene);
+}
+
+
+void SICADModel::loadModel(const std::basic_istream<char>* model_stream)
+{
+    std::ostringstream sstream;
+    sstream << model_stream->rdbuf();
+    const std::string model_data(sstream.str());
+    const char* model_data_pointer = model_data.c_str();
+
+    Assimp::Importer import;
+    const aiScene* scene = import.ReadFileFromMemory(model_data_pointer, model_data.length(), aiProcess_Triangulate | aiProcess_FlipUVs);
+
+    processNode(scene->mRootNode, scene);
+}
+
+
+void SICADModel::processNode(aiNode* node, const aiScene* scene)
+{
+    /* Process all the node's meshes (if any). */
+    for (GLuint i = 0; i < node->mNumMeshes; ++i)
+    {
+        aiMesh* mesh = scene->mMeshes[node->mMeshes[i]];
+        meshes_.push_back(processMesh(mesh, scene));
+    }
+
+    /* Then do the same for each of its children. */
+    for (GLuint i = 0; i < node->mNumChildren; ++i)
+    {
+        processNode(node->mChildren[i], scene);
+    }
+}
+
+
+Mesh SICADModel::processMesh(aiMesh* mesh, const aiScene* scene)
+{
+    std::vector<Mesh::Vertex> vertices;
+    std::vector<GLuint> indices;
+    std::vector<Mesh::Texture> textures;
+
+    /* Process vertices. */
+    for (GLuint i = 0; i < mesh->mNumVertices; ++i)
+    {
+        Mesh::Vertex vertex;
+
+        /* Process vertex positions, normals and texture coordinates. */
+        vertex.Position = glm::vec3(mesh->mVertices[i].x, mesh->mVertices[i].y, mesh->mVertices[i].z);
+        vertex.Normal = glm::vec3(mesh->mNormals[i].x,  mesh->mNormals[i].y,  mesh->mNormals[i].z);
+
+        /* Does the mesh contain texture coordinates? */
+        if (mesh->mTextureCoords[0])
+        {
+            vertex.TexCoords = glm::vec2(mesh->mTextureCoords[0][i].x, mesh->mTextureCoords[0][i].y);
+        }
+        else
+        {
+            vertex.TexCoords = glm::vec2(0.0f, 0.0f);
+        }
+
+        vertices.push_back(vertex);
+    }
+
+    /* Process indices. */
+    for (GLuint i = 0; i < mesh->mNumFaces; ++i)
+    {
+        aiFace face = mesh->mFaces[i];
+        for (GLuint j = 0; j < face.mNumIndices; ++j)
+        {
+            indices.push_back(face.mIndices[j]);
+        }
+    }
+
+    /* Process textures. */
+    /* The texture code is taken as-is. The tutorial on texture was skipped. */
+    if (mesh->mMaterialIndex > 0)
+    {
+        aiMaterial* material = scene->mMaterials[mesh->mMaterialIndex];
+
+        std::vector<Mesh::Texture> diffuseMaps = loadMaterialTextures(material, aiTextureType_DIFFUSE, "texture_diffuse");
+        textures.insert(textures.end(), diffuseMaps.begin(), diffuseMaps.end());
+
+        std::vector<Mesh::Texture> specularMaps = loadMaterialTextures(material, aiTextureType_SPECULAR, "texture_specular");
+        textures.insert(textures.end(), specularMaps.begin(), specularMaps.end());
+    }
+
+    return Mesh(vertices, indices, textures);
+}
+
+
+std::vector<Mesh::Texture> SICADModel::loadMaterialTextures(aiMaterial* mat, aiTextureType type, std::string typeName)
+{
+    std::vector<Mesh::Texture> textures;
+    for (GLuint i = 0; i < mat->GetTextureCount(type); ++i)
+    {
+        aiString str;
+        mat->GetTexture(type, i, &str);
+        GLboolean skip = false;
+        for (GLuint j = 0; j < textures_loaded_.size(); ++j)
+        {
+            if (textures_loaded_[j].path == str)
+            {
+                textures.push_back(textures_loaded_[j]);
+                skip = true;
+                break;
+            }
+        }
+
+        /* If texture hasn't been loaded already, load it. */
+        if (!skip)
+        {
+            Mesh::Texture texture;
+
+            texture.id = TextureFromFile(str.C_Str(), directory_);
+            texture.type = typeName;
+            texture.path = str;
+            textures.push_back(texture);
+
+            /* Add to loaded textures. */
+            textures_loaded_.push_back(texture);
+        }
+    }
+
+    return textures;
+}
+
+
+GLint SICADModel::TextureFromFile(const char* path, std::string directory)
+{
+    std::string filename = directory + "/" + std::string(path);
+    cv::Mat image = cv::imread(filename, cv::IMREAD_ANYCOLOR);
+
+    /* Generate texture ID and load texture data. */
+    GLuint textureID;
+    glGenTextures(1, &textureID);
+
+    /* Assign texture to ID. */
+    glBindTexture(GL_TEXTURE_2D, textureID);
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, image.cols, image.rows, 0, GL_RGB, GL_UNSIGNED_BYTE, image.ptr());
+    glGenerateMipmap(GL_TEXTURE_2D);
+
+    /* Parameters. */
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_REPEAT);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_REPEAT);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR_MIPMAP_LINEAR);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+    glBindTexture(GL_TEXTURE_2D, 0);
+
+    return textureID;
+}

--- a/src/roft-lib/src/SICADShader.cpp
+++ b/src/roft-lib/src/SICADShader.cpp
@@ -1,0 +1,160 @@
+/*
+ * Copyright (C) 2022 Istituto Italiano di Tecnologia (IIT)
+ *
+ * This software may be modified and distributed under the terms of the
+ * GPL-2+ license. See the accompanying LICENSE file for details.
+ *
+ *
+ * Part of this code is taken from https://github.com/robotology/superimpose-mesh-lib/commits/impl/depth
+ *
+ * This is the original BSD 3-Clause LICENSE the original code was provided with:
+ *
+ * Copyright (c) 2016-2019, Istituto Italiano di Tecnologia (IIT) All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+ * - Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ * - Neither the name of the organization nor the names of its contributors may be used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL CLAUDIO FANTACCI BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <ROFT/SICADShader.h>
+
+#include <cmrc/cmrc.hpp>
+CMRC_DECLARE(resources);
+
+#include <fstream>
+#include <sstream>
+#include <iostream>
+
+using namespace ROFT;
+
+
+SICADShader::SICADShader(const std::string& vertex_shader_path, const std::string& fragment_shader_path)
+{
+    std::string sourcecode_vertex_shader;
+    std::string sourcecode_fragmentshader;
+
+    /* Retrieve the vertex/fragment source code from path. */
+    try
+    {
+        auto cmrc_fs = cmrc::resources::get_filesystem();
+
+        if (cmrc_fs.exists(vertex_shader_path)   && cmrc_fs.is_file(vertex_shader_path) &&
+            cmrc_fs.exists(fragment_shader_path) && cmrc_fs.is_file(fragment_shader_path))
+        {
+            auto vertex_shader_cmrc_file = cmrc_fs.open(vertex_shader_path);
+            sourcecode_vertex_shader.assign(vertex_shader_cmrc_file.cbegin(), vertex_shader_cmrc_file.cend());
+
+
+            auto fragment_shader_cmrc_file = cmrc_fs.open(fragment_shader_path);
+            sourcecode_fragmentshader.assign(fragment_shader_cmrc_file.cbegin(), fragment_shader_cmrc_file.cend());
+        }
+        else
+        {
+            std::ifstream file_vertex_shader;
+            file_vertex_shader.exceptions(std::ifstream::badbit);
+
+            file_vertex_shader.open(vertex_shader_path);
+
+            std::stringstream vertex_shader_stream;
+            vertex_shader_stream << file_vertex_shader.rdbuf();
+
+            file_vertex_shader.close();
+
+
+            std::ifstream file_fragment_shader;
+            file_fragment_shader.exceptions(std::ifstream::badbit);
+
+            file_fragment_shader.open(fragment_shader_path);
+
+            std::stringstream fragment_shader_stream;
+            fragment_shader_stream << file_fragment_shader.rdbuf();
+
+            file_fragment_shader.close();
+
+
+            sourcecode_vertex_shader = vertex_shader_stream.str();
+            sourcecode_fragmentshader = fragment_shader_stream.str();
+        }
+    }
+    catch (const std::ifstream::failure& e)
+    {
+        throw std::runtime_error("ERROR::SHADER::CTOR\nERROR:\n\tCould not read shader source code.\n" + std::string(e.what()));
+    }
+
+
+    /* Compile shaders. */
+    const GLchar* ptr_sourcecode_vertex_shader = sourcecode_vertex_shader.c_str();
+    const GLchar* ptr_sourcecode_fragment_shader = sourcecode_fragmentshader.c_str();
+
+    GLuint vertex;
+    GLuint fragment;
+    GLint success;
+    GLchar info_log[512];
+
+    /* Vertex Shader. */
+    vertex = glCreateShader(GL_VERTEX_SHADER);
+    glShaderSource(vertex, 1, &ptr_sourcecode_vertex_shader, NULL);
+    glCompileShader(vertex);
+
+    /* Print compile errors if any. */
+    glGetShaderiv(vertex, GL_COMPILE_STATUS, &success);
+    if (!success)
+    {
+        glGetShaderInfoLog(vertex, 512, NULL, info_log);
+        throw std::runtime_error("ERROR::SHADER::CTOR\nERROR:\n\tVertex shader program compilation error.\nLOG:\n\t" + std::string(info_log));
+    };
+
+
+    /* Fragment Shader. */
+    fragment = glCreateShader(GL_FRAGMENT_SHADER);
+    glShaderSource(fragment, 1, &ptr_sourcecode_fragment_shader, NULL);
+    glCompileShader(fragment);
+
+    /* Print compile errors if any. */
+    glGetShaderiv(fragment, GL_COMPILE_STATUS, &success);
+    if (!success)
+    {
+        glGetShaderInfoLog(vertex, 512, NULL, info_log);
+        throw std::runtime_error("ERROR::SHADER::CTOR\nERROR:\n\tFragment shader program compilation error.\nLOG:\n\t" + std::string(info_log));
+    };
+
+
+    /* Shader Program. */
+    shader_program_id_ = glCreateProgram();
+    glAttachShader(shader_program_id_, vertex);
+    glAttachShader(shader_program_id_, fragment);
+    glLinkProgram(shader_program_id_);
+
+    /* Print linking errors if any. */
+    glGetProgramiv(shader_program_id_, GL_LINK_STATUS, &success);
+    if (!success)
+    {
+        glGetProgramInfoLog(shader_program_id_, 512, NULL, info_log);
+        throw std::runtime_error("ERROR::SHADER::CTOR\nERROR:\n\tShader program link fail.\nLOG:\n\t" + std::string(info_log));
+    }
+
+    /* Delete the shaders as they're linked into our program now and no longer necessery. */
+    glDeleteShader(vertex);
+    glDeleteShader(fragment);
+}
+
+
+void SICADShader::install()
+{
+    glUseProgram(shader_program_id_);
+}
+
+
+void SICADShader::uninstall()
+{
+    glUseProgram(0);
+}


### PR DESCRIPTION
This PR add some code required to allow `superimpose-mesh-lib`:
- render depth 
- handle object meshes from a virtual filesystem

This will allow detaching from non-official branches and use `superimpose-mesh-lib` from the devel branch.

The solution is temporary though, as those features might be added to the repository of `superimpose-mesh-lib` sooner or later.